### PR TITLE
docs: promote Qwen Code to plugin-marketplace harness in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Or run one action at a time — `bash install.sh install` / `configure` / `verif
 
 Prefer your harness's own commands — or you're on opencode / pi / QwenPaw, which the installer doesn't cover? Register the skill + MCP yourself.
 
-**Plugin-marketplace harnesses** (Claude Code · Qoder · Codex · OpenClaw) — add the marketplace, then install a capability (replace `<cap>` with `core` / `video-memory` / `video-edit` / `blender` / `freecad`):
+**Plugin-marketplace harnesses** (Claude Code · Qoder · Codex · OpenClaw · Qwen Code) — add the marketplace, then install a capability (replace `<cap>` with `core` / `video-memory` / `video-edit` / `blender` / `freecad`):
 
 ```bash
 # Claude Code
@@ -65,11 +65,13 @@ codex    plugin  marketplace add https://github.com/QwenLM/Qwen-MM-Plugins.git
 codex    plugin  add           qwen-mm-plugins-<cap>@qwen-mm-plugins
 # OpenClaw
 openclaw plugins install       qwen-mm-plugins-<cap> --marketplace https://github.com/QwenLM/Qwen-MM-Plugins.git
+# Qwen Code
+qwen extensions install https://github.com/QwenLM/Qwen-MM-Plugins.git:qwen-mm-plugins-<cap> --consent
 ```
 
 `marketplace add` also accepts a local repo path; re-running is safe. On **codex**, `marketplace add` does **not** refresh an already-added marketplace, so run `codex plugin marketplace upgrade qwen-mm-plugins` before `plugin add` to pick up newly-published capabilities.
 
-**Other harnesses** (Qwen Code · Gemini CLI · opencode · pi · QwenPaw · …) register the skill + MCP in their own config — exact per-harness blocks are in [`docs/en/installation.md`](docs/en/installation.md). Easiest of all: **just ask the agent** — "install `qwen-mm-plugins-<cap>`".
+**Other harnesses** (Gemini CLI · opencode · pi · QwenPaw · …) register the skill + MCP in their own config — exact per-harness blocks are in [`docs/en/installation.md`](docs/en/installation.md). Easiest of all: **just ask the agent** — "install `qwen-mm-plugins-<cap>`".
 
 ## 🔧 Dependencies
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -51,7 +51,7 @@ curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install
 
 想用 harness 自己的命令，或你在 opencode / pi / QwenPaw 上（安装器不覆盖这几个）？那就自己注册 skill + MCP。
 
-**有插件市场的 harness**（Claude Code · Qoder · Codex · OpenClaw）—— 加市场，再装某个能力（把 `<cap>` 换成 `core` / `video-memory` / `video-edit` / `blender` / `freecad`）：
+**有插件市场的 harness**（Claude Code · Qoder · Codex · OpenClaw · Qwen Code）—— 加市场，再装某个能力（把 `<cap>` 换成 `core` / `video-memory` / `video-edit` / `blender` / `freecad`）：
 
 ```bash
 # Claude Code
@@ -65,11 +65,13 @@ codex    plugin  marketplace add https://github.com/QwenLM/Qwen-MM-Plugins.git
 codex    plugin  add           qwen-mm-plugins-<cap>@qwen-mm-plugins
 # OpenClaw
 openclaw plugins install       qwen-mm-plugins-<cap> --marketplace https://github.com/QwenLM/Qwen-MM-Plugins.git
+# Qwen Code
+qwen extensions install https://github.com/QwenLM/Qwen-MM-Plugins.git:qwen-mm-plugins-<cap> --consent
 ```
 
 `marketplace add` 也接受本地仓库路径；重复执行是安全的。在 **codex** 上，`marketplace add` **不会**刷新已添加的 marketplace，所以要装入新增能力时，先执行 `codex plugin marketplace upgrade qwen-mm-plugins` 再 `plugin add`。
 
-**其它 harness**（Qwen Code · Gemini CLI · opencode · pi · QwenPaw · …）在各自配置里注册 skill + MCP —— 各 harness 的精确配置块见 [`docs/zh/installation.md`](docs/zh/installation.md)。最省事：**直接让 agent 帮你装** —— 「装一下 `qwen-mm-plugins-<cap>`」。
+**其它 harness**（Gemini CLI · opencode · pi · QwenPaw · …）在各自配置里注册 skill + MCP —— 各 harness 的精确配置块见 [`docs/zh/installation.md`](docs/zh/installation.md)。最省事：**直接让 agent 帮你装** —— 「装一下 `qwen-mm-plugins-<cap>`」。
 
 ## 🔧 依赖
 


### PR DESCRIPTION
## What changed

- Add Qwen Code to the **Plugin-marketplace harnesses** section in `README.md` / `README.zh.md`, alongside Claude Code / Qoder / Codex / OpenClaw
- Include the verified one-liner install command: `qwen extensions install <git-url>:qwen-mm-plugins-<cap> --consent`
- Remove Qwen Code from the **Other harnesses** list, since it's a single-command marketplace install, not manual registration

<details>
<summary>中文</summary>

- 在 `README.md` / `README.zh.md` 的 **Plugin-marketplace harnesses** 一节加入 Qwen Code（与 Claude Code / Qoder / Codex / OpenClaw 并列）
- 给出已验证的一行命令安装方式：`qwen extensions install <git-url>:qwen-mm-plugins-<cap> --consent`
- 从 **Other harnesses** 一节移除 Qwen Code —— 它本身就是一条命令的 marketplace 级集成，不是手动注册 skill + MCP

</details>

## Verification

End-to-end on a clean install:

1. `qwen extensions install https://github.com/QwenLM/Qwen-MM-Plugins.git:qwen-mm-plugins-core --consent` — installed successfully
2. `qwen extensions list` — skill + MCP server registered
3. MCP server (`uvx --from "qwen-mm-plugins[core] @ git+..."`) built 93 packages, `tools/list` returned all 14 tools
4. Headless `qwen -p "..." --yolo -o text` reading a test image succeeded

<img width="1974" height="1024" alt="image" src="https://github.com/user-attachments/assets/70130f88-0cb0-4d9c-8a0d-375b55979350" />

<details>
<summary>中文</summary>

在干净环境端到端验证：

1. `qwen extensions install https://github.com/QwenLM/Qwen-MM-Plugins.git:qwen-mm-plugins-core --consent` — 安装成功
2. `qwen extensions list` — skill + MCP server 已注册
3. MCP server（`uvx --from "qwen-mm-plugins[core] @ git+..."`）构建 93 个包，`tools/list` 返回全部 14 个工具
4. 无头 `qwen -p "..." --yolo -o text` 读取测试图片成功

</details>

## Compatibility

- [x] Existing MCP tool names, inputs, and outputs are unchanged, or the change is explained above.
- [x] Tests and documentation were updated where behavior changed.
- [x] No credentials, private media, generated artifacts, or machine-specific configuration are included.
