### PR TITLE
fix(install): add localize subcommand to make stdio MCP work in sandboxed GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ One script handles **install · configure · verify · uninstall** across every 
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash
 ```
 
-Or run one action at a time — `bash install.sh install` / `configure` / `verify` / `uninstall` / `localize` / `uninstall` (what each does is detailed under [Configuration](#-configuration) and [Dependencies](#-dependencies); `localize` is the escape hatch for sandboxed GUI harnesses — see [Sandboxed GUI harnesses](docs/en/installation.md#sandboxed-gui-harnesses-codex-desktop-claude-qoder--network-restrictions)).
+Or run one action at a time — `bash install.sh install` / `configure` / `verify` / `localize` / `uninstall` (what each does is detailed under [Configuration](#-configuration) and [Dependencies](#-dependencies); `localize` is the escape hatch for sandboxed GUI harnesses — see [Sandboxed GUI harnesses](docs/en/installation.md#sandboxed-gui-harnesses-codex-desktop-claude-qoder--network-restrictions)).
 
 **Windows x64:** use WSL2 (Ubuntu recommended) and clone the repository inside your WSL
 home directory (for example `~/code`), rather than under a mounted Windows drive such as

--- a/README.md
+++ b/README.md
@@ -46,13 +46,21 @@ One script handles **install · configure · verify · uninstall** across every 
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash
 ```
 
-Or run one action at a time — `bash install.sh install` / `configure` / `verify` / `uninstall` (what `configure` and `verify` do is detailed under [Configuration](#-configuration) and [Dependencies](#-dependencies)).
+Or run one action at a time — `bash install.sh install` / `configure` / `verify` / `uninstall` / `localize` / `uninstall` (what each does is detailed under [Configuration](#-configuration) and [Dependencies](#-dependencies); `localize` is the escape hatch for sandboxed GUI harnesses — see [Sandboxed GUI harnesses](docs/en/installation.md#sandboxed-gui-harnesses-codex-desktop-claude-qoder--network-restrictions)).
 
 **Windows x64:** use WSL2 (Ubuntu recommended) and clone the repository inside your WSL
 home directory (for example `~/code`), rather than under a mounted Windows drive such as
 `/mnt/c`. Then run the same commands there. WSL2 is currently the only supported Windows
 environment; native Windows has not yet been validated. See the concise
 [Windows notes](docs/en/installation.md#windows-wsl2).
+
+> **Using Codex desktop / Claude / Qoder and seeing `unsupported call`?**
+> The Electron sandbox blocks the spawned `uvx` from reaching `github.com`. Run
+> `bash install.sh localize` from a local checkout to rewrite the stdio URLs to `file://…`,
+> then fully quit and relaunch the GUI. Details:
+> [Sandboxed GUI harnesses](docs/en/installation.md#sandboxed-gui-harnesses-codex-desktop-claude-qoder--network-restrictions).
+
+
 
 ### By hand (per-harness)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -46,12 +46,19 @@
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash   # 引导菜单
 ```
 
-也可以只跑单个动作 —— `bash install.sh install` / `configure` / `verify` / `uninstall`（`configure` 和 `verify` 各自做什么，见下面的[配置](#-配置)与[依赖](#-依赖)）。
+也可以只跑单个动作 —— `bash install.sh install` / `configure` / `verify` / `uninstall` / `localize` / `uninstall`（各动作的细节见[配置](#-配置)与[依赖](#-依赖)；`localize` 是给沙盒化 GUI harness 用的逃生口，见[沙盒化 GUI harness 的网络限制](docs/zh/installation.md#沙盒化-gui-harness-的网络限制codex-桌面--claude--qoder-等)）。
 
 **Windows x64：**推荐使用 WSL2（建议 Ubuntu），在 WSL home 目录中 clone 仓库
 （例如 `~/code`），不要放在 `/mnt/c` 这类 Windows 挂载盘下，然后运行相同命令。
 当前 Windows 仅支持 WSL2；原生 Windows 尚未完成验证。简要说明见
 [Windows 安装说明](docs/zh/installation.md#windows-wsl2)。
+
+> **在 Codex 桌面 / Claude / Qoder 里看到工具调用返回 `unsupported call`？**
+> 它们的 Electron 沙盒禁止子进程访问 `github.com`。在本仓库的 checkout 里跑一次
+> `bash install.sh localize` 把 stdio URL 改写成 `file://…`，然后**完全退出并重启** GUI 即可。
+> 详见 [沙盒化 GUI harness 的网络限制](docs/zh/installation.md#沙盒化-gui-harness-的网络限制codex-桌面--claude--qoder-等)。
+
+
 
 ### 手动（逐 harness）
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -46,7 +46,7 @@
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash   # 引导菜单
 ```
 
-也可以只跑单个动作 —— `bash install.sh install` / `configure` / `verify` / `uninstall` / `localize` / `uninstall`（各动作的细节见[配置](#-配置)与[依赖](#-依赖)；`localize` 是给沙盒化 GUI harness 用的逃生口，见[沙盒化 GUI harness 的网络限制](docs/zh/installation.md#沙盒化-gui-harness-的网络限制codex-桌面--claude--qoder-等)）。
+也可以只跑单个动作 —— `bash install.sh install` / `configure` / `verify` / `localize` / `uninstall`（各动作的细节见[配置](#-配置)与[依赖](#-依赖)；`localize` 是给沙盒化 GUI harness 用的逃生口，见[沙盒化 GUI harness 的网络限制](docs/zh/installation.md#沙盒化-gui-harness-的网络限制codex-桌面--claude--qoder-等)）。
 
 **Windows x64：**推荐使用 WSL2（建议 Ubuntu），在 WSL home 目录中 clone 仓库
 （例如 `~/code`），不要放在 `/mnt/c` 这类 Windows 挂载盘下，然后运行相同命令。

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -239,6 +239,8 @@ Idempotent: a second `localize` reports `unchanged 6 (already on file://)` and r
 
 Roll back: manually replace each `file://...` in `src/capabilities/<cap>/.mcp.json` with `qwen-mm-plugins[<cap>] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@main`, or `git checkout -- src/capabilities/*/.mcp.json`.
 
+> **Relationship to `scripts/dev-plugin.sh`.** `dev-plugin.sh` was the first tool in the repo to flip plugin manifests to `file://` (it was for the dev-time `claude plugin install` flow). With this PR, both `dev-plugin.sh` and the new `install.sh localize` delegate to a single shared helper — `scripts/_flip_mcp.py` — so the rewrite logic lives in exactly one place and can never drift. `dev-plugin.sh` keeps the dev-time `--refresh` flag and per-cap scope; `localize` runs across all caps and stays `--refresh`-free so the uvx cache stays compatible with non-sandboxed installs.
+
 > **Why do I need a second `localize` after `install.sh install`?** `install` only drives the harness's native `plugin install` flow, which reads the `git+https://...` URL baked into `.mcp.json` in the repo. To make stdio children use a local path you have to rewrite `.mcp.json` afterwards, and relaunch the GUI harness to pick the change up.
 
 ## Repository layout

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -208,6 +208,39 @@ Config is read from the shell environment, falling back to `~/.qwen-mm-plugins/c
 
 > **blender / freecad** are thin clients — they connect to a **running** Blender / FreeCAD carrying the bundled addon. `QWEN_MM_AUTOLAUNCH=1` (preset in the plugin manifests) brings the app up on the first tool call, auto-downloading it on Linux-x86_64 if missing. See [`cookbooks/blender`](../../cookbooks/blender/usage.md) / [`cookbooks/freecad`](../../cookbooks/freecad/usage.md) for the full setup, env vars, and troubleshooting.
 
+## Sandboxed GUI harnesses (Codex desktop, Claude, Qoder) — network restrictions
+
+When you use **Codex desktop** (the macOS / Windows sandboxed Electron build), Claude Desktop, Qoder, or any GUI client that spawns stdio MCP servers as restricted children, you may hit this symptom:
+
+- `codex mcp list` (or the equivalent on your harness) shows every `qwen-mm-plugins-*` server as `enabled`
+- The tools appear in the LLM's tool list, but **every call returns `unsupported call`**
+- The same `uvx --from "qwen-mm-plugins[<cap>] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@main" qwen-mm-plugins-<cap>` works fine when run by hand in your shell
+
+Root cause: the harness's Electron sandbox **blocks the spawned stdio child from reaching the public network** (a tell-tale is `codex plugin marketplace upgrade qwen-mm-plugins` also failing with `Could not resolve host: github.com`). The child `uvx` first run needs to fetch the package from `git+https://github.com/...`, hits a DNS failure, exits silently, and the harness falls back to reporting `unsupported call`.
+
+Fix: rewrite `.mcp.json` to use a `file://<local checkout>` URL so `uvx` installs from disk and never reaches GitHub. `install.sh` ships a `localize` subcommand that does this in place:
+
+```bash
+# 1) Grab a local checkout by any means (git clone, Codex marketplace, curl|bash, …)
+git clone https://github.com/QwenLM/Qwen-MM-Plugins.git ~/qwen-mm-plugins
+cd ~/qwen-mm-plugins
+
+# 2) Run install.sh localize — defaults to this repo's src/ tree
+bash install.sh localize
+# or point it at a different checkout:
+# QMP_REPO=file:///path/to/another/checkout/src bash install.sh localize
+
+# 3) **Fully quit and relaunch your GUI harness** (Codex desktop, Claude, Qoder, …).
+# A fresh stdio child is only spawned on the first call of a new session —
+# any session that was already open will keep using the old URL.
+```
+
+Idempotent: a second `localize` reports `unchanged 6 (already on file://)` and rewrites nothing. After `git pull` just re-run `localize` to repoint at the updated checkout (no need to re-run `plugin install`).
+
+Roll back: manually replace each `file://...` in `src/capabilities/<cap>/.mcp.json` with `qwen-mm-plugins[<cap>] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@main`, or `git checkout -- src/capabilities/*/.mcp.json`.
+
+> **Why do I need a second `localize` after `install.sh install`?** `install` only drives the harness's native `plugin install` flow, which reads the `git+https://...` URL baked into `.mcp.json` in the repo. To make stdio children use a local path you have to rewrite `.mcp.json` afterwards, and relaunch the GUI harness to pick the change up.
+
 ## Repository layout
 
 ```

--- a/docs/zh/installation.md
+++ b/docs/zh/installation.md
@@ -206,6 +206,38 @@ qwenpaw skills config    # 交互勾选启用
 
 > **blender / freecad** 是瘦客户端 —— 它们连接到一台**正在运行**、装好随包 addon 的 Blender / FreeCAD。`QWEN_MM_AUTOLAUNCH=1`（插件清单里默认预设）会在第一次工具调用时把应用拉起来，Linux-x86_64 上缺应用时自动下载。完整安装、环境变量与排障见 [`cookbooks/blender`](../../cookbooks/blender/usage.md) / [`cookbooks/freecad`](../../cookbooks/freecad/usage.md)。
 
+## 沙盒化 GUI harness 的网络限制（Codex 桌面 / Claude / Qoder 等）
+
+当你用 **Codex 桌面**（macOS / Windows 沙盒化的 Electron 应用）、Claude Desktop、Qoder 或任何把 stdio MCP server 当作受限子进程拉起的 GUI 客户端时，可能遇到这个症状：
+
+- `codex mcp list`（或对应 harness 的 mcp 列表命令）里所有 `qwen-mm-plugins-*` server 状态都是 `enabled`
+- 工具在 LLM 端能看到，**但每次调用都返回 `unsupported call`**
+- 单独在 shell 里跑 `uvx --from "qwen-mm-plugins[<cap>] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@main" qwen-mm-plugins-<cap>` 是正常的
+
+根因是：harness 的 Electron 沙盒在 spawn stdio 子进程时**禁止访问公网**（典型表现是 `codex plugin marketplace upgrade qwen-mm-plugins` 也报 `Could not resolve host: github.com`）。子进程 `uvx` 第一次启动需要从 `git+https://github.com/...` 拉包 → DNS 解析失败 → 进程静默退出 → harness 把这次调用回退成 "unsupported call"。
+
+修复：把 `.mcp.json` 里的 `git+https://...` 改写为 `file://<本地 checkout>`，让 `uvx` 直接从本地装，不再访问 GitHub。`install.sh` 已经把这个流程封装成 `localize` 子命令：
+
+```bash
+# 1) 拿一份本地 checkout（任何方式都行：git clone、Codex marketplace、curl|bash）
+git clone https://github.com/QwenLM/Qwen-MM-Plugins.git ~/qwen-mm-plugins
+cd ~/qwen-mm-plugins
+
+# 2) 跑 install.sh localize —— 默认就用本仓库的 src/ 目录
+bash install.sh localize
+# 或显式指定一个不同的 checkout：
+# QMP_REPO=file:///path/to/another/checkout/src bash install.sh localize
+
+# 3) **完全退出并重启你的 GUI harness**（Codex 桌面、Claude、Qoder 等）
+# 每个新会话首次调用才 spawn stdio 子进程 —— 已经打开的会话仍会用旧 URL。
+```
+
+幂等：再跑一次 `localize` 会显示 `unchanged 6 (already on file://)`，不会重复改写。`git pull` 之后再跑一次即可让本地路径指向最新代码（不需要重新 `plugin install`）。
+
+回滚：手动把每个 `src/capabilities/<cap>/.mcp.json` 里的 `file://...` 改回 `qwen-mm-plugins[<cap>] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@main`，或者 `git checkout -- src/capabilities/*/.mcp.json`。
+
+> **为什么 `install.sh install` 之后还要再跑一次 `localize`？** `install` 只调用 harness 的 `plugin install` 流程，那个流程直接读仓库里写死的 `.mcp.json`（默认是 `git+https://...`）；要让 stdio 子进程用本地路径，必须额外跑 `localize` 改写 `.mcp.json`。改完请重启 GUI harness 才会生效。
+
 ## 目录结构
 
 ```

--- a/docs/zh/installation.md
+++ b/docs/zh/installation.md
@@ -236,6 +236,8 @@ bash install.sh localize
 
 回滚：手动把每个 `src/capabilities/<cap>/.mcp.json` 里的 `file://...` 改回 `qwen-mm-plugins[<cap>] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@main`，或者 `git checkout -- src/capabilities/*/.mcp.json`。
 
+> **与 `scripts/dev-plugin.sh` 的关系。** `dev-plugin.sh` 是仓库里最早把 plugin manifest 切到 `file://` 的工具(为了 dev-time 的 `claude plugin install` 流)。本 PR 之后,`dev-plugin.sh` 和新加的 `install.sh localize` 都委托给同一个共享脚本 `scripts/_flip_mcp.py`,改写逻辑只在一处维护,两路永远不会漂移。`dev-plugin.sh` 保留 dev-time 的 `--refresh` 标志和单 cap 粒度;`localize` 跨所有 cap 批量跑,且不加 `--refresh`,让 uvx 缓存跟非沙盒安装兼容。
+
 > **为什么 `install.sh install` 之后还要再跑一次 `localize`？** `install` 只调用 harness 的 `plugin install` 流程，那个流程直接读仓库里写死的 `.mcp.json`（默认是 `git+https://...`）；要让 stdio 子进程用本地路径，必须额外跑 `localize` 改写 `.mcp.json`。改完请重启 GUI harness 才会生效。
 
 ## 目录结构

--- a/install.sh
+++ b/install.sh
@@ -116,7 +116,7 @@ export PATH
 # Non-interactive forms (--verify / --help) run headless (CI, curl|bash -s -- --verify) and need no
 # terminal; every other invocation is an interactive TUI that reads keys from the tty (fd 3).
 NONINTERACTIVE=0
-case "${1:-}" in --verify|-h|--help) NONINTERACTIVE=1; QMP_NO_TUI=1 ;; esac
+case "${1:-}" in --verify|-h|--help|localize) NONINTERACTIVE=1; QMP_NO_TUI=1 ;; esac
 # ── an interactive terminal, even under `curl | bash` (stdin is the pipe → read from /dev/tty) ──
 if [ "$NONINTERACTIVE" = 1 ]; then
   exec 3</dev/null                                   # headless: no prompts, no terminal required
@@ -1085,17 +1085,100 @@ do_uninstall() {
   pause   # hold the uninstall result on screen before the menu reclears
 }
 
+# do_localize — rewrite every src/capabilities/<cap>/.mcp.json so its uvx --from points at a
+# local file:// path instead of git+https://github.com/.../Qwen-MM-Plugins.git. Use this when
+# your harness launches MCP servers as sandboxed stdio children that cannot resolve
+# github.com (e.g. the Codex desktop app on macOS, where the Electron sandbox blocks the
+# spawned uvx from reaching the network). Symptom: every tool call returns "unsupported
+# call" even though `codex mcp list` shows the servers as enabled. Honors QMP_REPO
+# (default: directory holding this install.sh, after symlink resolution); if QMP_REPO is
+# already a file:// URL it is used verbatim. Re-run after each `git pull` so the .mcp.json
+# keeps tracking the live checkout, and restart the GUI app afterwards (Codex spawns stdio
+# servers lazily on first tool call — an in-flight session will still try the old URL).
+do_localize() {
+  local repo_path repo_url changed=0 failed=0 already=0
+  # Resolve the install.sh directory: BASH_SOURCE survives `bash -c`, `source`, and stdin-piped
+  # installs (where $0 is just "bash" and dirname would point at /tmp or similar). -P dereferences
+  # any symlink so the file:// URL points at the real checkout, not a wrapper.
+  local here script_path="${BASH_SOURCE[0]:-$0}"
+  here=$(cd "$(dirname "$script_path")" && pwd -P)
+  case "${QMP_REPO:-}" in
+    file://*) repo_url=$QMP_REPO ;;
+    "")       repo_url="file://$here/src" ;;            # default: the src/ tree of this checkout
+    /*|./*|../*)
+                if [ -d "$QMP_REPO" ]; then
+                  repo_path=$(cd "$QMP_REPO" 2>/dev/null && pwd -P) || { err "QMP_REPO is not a directory: $QMP_REPO"; return 1; }
+                  repo_url="file://$repo_path"
+                else
+                  err "QMP_REPO is set to a non-directory path: $QMP_REPO"; return 1
+                fi ;;
+    *)        err "QMP_REPO must be a file:// URL or a local directory (got: $QMP_REPO)"; return 1 ;;
+  esac
+  # PEP-508 requires escaping in file:// URLs.
+  local esc; esc=$(printf '%s' "$repo_url" | python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.stdin.read(), safe='/:@!'))")
+  screen; hr "Localize MCP sources → $esc"
+  local cap f
+  for cap in "${CAP_ITEMS[@]}"; do
+    is_skill_only "$cap" && continue
+    f="src/capabilities/$cap/.mcp.json"
+    [ -f "$f" ] || continue
+    if grep -qF "file://" "$f" && ! grep -qF "git+https://github.com/QwenLM/Qwen-MM-Plugins.git" "$f"; then
+      # Already on a file:// URL (path may differ from this run's QMP_REPO — that's fine, just
+      # reports `unchanged`. User can `git pull` and re-run to pick up the new path).
+      already=$((already + 1))
+      printf '  %b✓%b %s (already on file://)\n' "$CG" "$C0" "$f"
+      continue
+    fi
+    if grep -qF "git+https://github.com/QwenLM/Qwen-MM-Plugins.git" "$f"; then
+      # in-place replace the hardcoded git URL with the file:// URL on every .mcp.json
+      python3 - "$f" "$esc" <<'PYEOF'
+import json, sys, pathlib
+fp, new_url = sys.argv[1], sys.argv[2]
+data = json.loads(pathlib.Path(fp).read_text())
+for srv in data.get("mcpServers", {}).values():
+    args = srv.get("args", [])
+    for i, a in enumerate(args):
+        if isinstance(a, str) and a.startswith("qwen-mm-plugins[") and "@ git+" in a:
+            cap = a.split("[", 1)[1].split("]", 1)[0]
+            args[i] = f"qwen-mm-plugins[{cap}] @ {new_url}"
+pathlib.Path(fp).write_text(json.dumps(data, indent=2) + "\n")
+PYEOF
+      if [ $? -eq 0 ]; then
+        changed=$((changed + 1))
+        printf '  %b✓%b %s\n' "$CG" "$C0" "$f"
+      else
+        failed=$((failed + 1))
+        printf '  %b✗%b %s (rewrite failed)\n' "$CR" "$C0" "$f"
+      fi
+    else
+      printf '  %b-%b %s (no git+https URL found — already custom?)\n' "$CY" "$C0" "$f"
+    fi
+  done
+  printf '\n'
+  box_open "Localize summary"
+  box_row "rewrote   ${CG}$changed${C0}"
+  box_row "unchanged ${CD}$already${C0} (already file://)"
+  [ "$failed" -gt 0 ] && box_row "failed    ${CR}$failed${C0}"
+  box_close
+  if [ "$changed" -gt 0 ]; then
+    printf '\n  %bNext:%b restart your GUI harness (Codex desktop, Claude, Qoder, etc.) so it re-reads .mcp.json.\n' "$CB" "$C0"
+    printf '  Each new turn spawns a fresh stdio child, so an in-flight session will still hit the old URL.\n'
+  fi
+  pause
+}
+
 menu() {
   while :; do
     screen
     status
     menu_pick "What would you like to do?" \
-      "Install plugin" "Configure (API key + all settings)" "Verify" "Uninstall" "Quit"
+      "Install plugin" "Configure (API key + all settings)" "Verify" "Localize (sandboxed GUI)" "Uninstall" "Quit"
     case "$PICK_I" in
       0) do_install ;;
       1) do_configure ;;
       2) do_verify ;;
-      3) do_uninstall ;;
+      3) do_localize ;;
+      4) do_uninstall ;;
       *) printf '\n  bye 👋\n\n'; exit 0 ;;   # "Quit" or cancelled (q/Esc)
     esac
     # Each action pauses on its own result screen; only cancel/back paths return straight here.
@@ -1106,8 +1189,9 @@ case "${1:-}" in
   install)   do_install ;;
   configure) do_configure ;;
   verify)    do_verify ;;
+  localize)  do_localize ;;
   uninstall) do_uninstall ;;
   --verify)  shift; run_caps_noninteractive "$@" ;;
-  -h|--help) banner; printf '\n  Usage: install.sh [install|configure|verify|uninstall]   (no arg = interactive menu)\n         install.sh --verify [caps]   # non-interactive: check installed (or listed) caps\n\n  (No update action — uvx re-resolves the pinned git ref and pulls new commits on each launch.)\n\n' ;;
+  -h|--help) banner; printf '\n  Usage: install.sh [install|configure|verify|localize|uninstall]   (no arg = interactive menu)\n         install.sh --verify [caps]   # non-interactive: check installed (or listed) caps\n         install.sh localize            # rewrite .mcp.json to a local file:// URL (sandboxed GUI)\n\n  (No update action — uvx re-resolves the pinned git ref and pulls new commits on each launch.)\n  "localize" is the escape hatch when a sandboxed GUI (Codex desktop, etc.) blocks stdio\n  children from reaching github.com — see docs/en/installation.md → "Sandboxed GUI harnesses".\n\n' ;;
   *)         menu ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -1087,24 +1087,27 @@ do_uninstall() {
 
 # do_localize — rewrite every src/capabilities/<cap>/.mcp.json so its uvx --from points at a
 # local file:// path instead of git+https://github.com/.../Qwen-MM-Plugins.git. Use this when
-# your harness launches MCP servers as sandboxed stdio children that cannot resolve
-# github.com (e.g. the Codex desktop app on macOS, where the Electron sandbox blocks the
-# spawned uvx from reaching the network). Symptom: every tool call returns "unsupported
-# call" even though `codex mcp list` shows the servers as enabled. Honors QMP_REPO
-# (default: directory holding this install.sh, after symlink resolution); if QMP_REPO is
-# already a file:// URL it is used verbatim. Re-run after each `git pull` so the .mcp.json
-# keeps tracking the live checkout, and restart the GUI app afterwards (Codex spawns stdio
-# servers lazily on first tool call — an in-flight session will still try the old URL).
+# your harness launches MCP servers as sandboxed stdio children that cannot resolve github.com
+# (e.g. the Codex desktop app on macOS, where the Electron sandbox blocks the spawned uvx from
+# reaching the network). Symptom: every tool call returns "unsupported call" even though
+# `codex mcp list` shows the servers as enabled. Honors QMP_REPO (default: directory holding
+# this install.sh, after symlink resolution); if QMP_REPO is already a file:// URL it is used
+# verbatim. Re-run after each `git pull` so the rewritten .mcp.json keeps tracking the live
+# checkout, and restart the GUI app afterwards (Codex spawns stdio servers lazily on first
+# tool call — an in-flight session will still try the old URL).
+#
+# The actual manifest-rewriting is shared with `scripts/dev-plugin.sh` via
+# `scripts/_flip_mcp.py` — dev-plugin adds `--refresh` for source iteration; localize does
+# not, so the uvx cache stays compatible with non-sandboxed installs.
 do_localize() {
-  local repo_path repo_url changed=0 failed=0 already=0
   # Resolve the install.sh directory: BASH_SOURCE survives `bash -c`, `source`, and stdin-piped
   # installs (where $0 is just "bash" and dirname would point at /tmp or similar). -P dereferences
   # any symlink so the file:// URL points at the real checkout, not a wrapper.
-  local here script_path="${BASH_SOURCE[0]:-$0}"
+  local repo_path repo_url here script_path="${BASH_SOURCE[0]:-$0}" flippers=()
   here=$(cd "$(dirname "$script_path")" && pwd -P)
   case "${QMP_REPO:-}" in
     file://*) repo_url=$QMP_REPO ;;
-    "")       repo_url="file://$here/src" ;;            # default: the src/ tree of this checkout
+    "")       repo_url="file://$here" ;;                 # default: this checkout (root, not src/)
     /*|./*|../*)
                 if [ -d "$QMP_REPO" ]; then
                   repo_path=$(cd "$QMP_REPO" 2>/dev/null && pwd -P) || { err "QMP_REPO is not a directory: $QMP_REPO"; return 1; }
@@ -1114,53 +1117,43 @@ do_localize() {
                 fi ;;
     *)        err "QMP_REPO must be a file:// URL or a local directory (got: $QMP_REPO)"; return 1 ;;
   esac
-  # PEP-508 requires escaping in file:// URLs.
-  local esc; esc=$(printf '%s' "$repo_url" | python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.stdin.read(), safe='/:@!'))")
-  screen; hr "Localize MCP sources → $esc"
-  local cap f
+  # _flip_mcp.py handles the PEP-508 percent-escaping of the path; we hand it the absolute
+  # filesystem path (it prepends file:// itself).
+  local repo_path_for_py
+  case "$repo_url" in
+    file://*) repo_path_for_py=${repo_url#file://} ;;
+    *)        repo_path_for_py=$repo_url ;;
+  esac
+  screen; hr "Localize MCP sources → $repo_url"
+  local cap f status
   for cap in "${CAP_ITEMS[@]}"; do
     is_skill_only "$cap" && continue
     f="src/capabilities/$cap/.mcp.json"
     [ -f "$f" ] || continue
-    if grep -qF "file://" "$f" && ! grep -qF "git+https://github.com/QwenLM/Qwen-MM-Plugins.git" "$f"; then
-      # Already on a file:// URL (path may differ from this run's QMP_REPO — that's fine, just
-      # reports `unchanged`. User can `git pull` and re-run to pick up the new path).
-      already=$((already + 1))
-      printf '  %b✓%b %s (already on file://)\n' "$CG" "$C0" "$f"
-      continue
-    fi
-    if grep -qF "git+https://github.com/QwenLM/Qwen-MM-Plugins.git" "$f"; then
-      # in-place replace the hardcoded git URL with the file:// URL on every .mcp.json
-      python3 - "$f" "$esc" <<'PYEOF'
-import json, sys, pathlib
-fp, new_url = sys.argv[1], sys.argv[2]
-data = json.loads(pathlib.Path(fp).read_text())
-for srv in data.get("mcpServers", {}).values():
-    args = srv.get("args", [])
-    for i, a in enumerate(args):
-        if isinstance(a, str) and a.startswith("qwen-mm-plugins[") and "@ git+" in a:
-            cap = a.split("[", 1)[1].split("]", 1)[0]
-            args[i] = f"qwen-mm-plugins[{cap}] @ {new_url}"
-pathlib.Path(fp).write_text(json.dumps(data, indent=2) + "\n")
-PYEOF
-      if [ $? -eq 0 ]; then
-        changed=$((changed + 1))
-        printf '  %b✓%b %s\n' "$CG" "$C0" "$f"
-      else
-        failed=$((failed + 1))
-        printf '  %b✗%b %s (rewrite failed)\n' "$CR" "$C0" "$f"
-      fi
-    else
-      printf '  %b-%b %s (no git+https URL found — already custom?)\n' "$CY" "$C0" "$f"
-    fi
+    flippers+=("$f")
   done
+  [ ${#flippers[@]} -gt 0 ] || { warn "no .mcp.json files found under src/capabilities/ — nothing to localize"; pause; return 0; }
+  # Run the shared flipper once for every file; it prints "<status>\t<path>" per line, where
+  # status ∈ {ok, unchanged, skip:..., fail:...}. We tally and render a summary box.
+  local rewrote=0 unchanged=0 failed=0 line status_color
+  while IFS= read -r line; do
+    status=${line%%	*}
+    f=${line##*	}
+    case "$status" in
+      ok)        rewrote=$((rewrote+1));    status_color="${CG}✓${C0} $f" ;;
+      unchanged) unchanged=$((unchanged+1)); status_color="${CG}✓${C0} $f (already on file://)" ;;
+      skip:*)    status_color="${CD}-${C0} $f (${status#skip:})" ;;
+      *)         failed=$((failed+1));       status_color="${CR}✗${C0} $f ($status)" ;;
+    esac
+    printf '  %b\n' "$status_color"
+  done < <(REPO="$repo_path_for_py" "$here/scripts/_flip_mcp.py" "${flippers[@]}")
   printf '\n'
   box_open "Localize summary"
-  box_row "rewrote   ${CG}$changed${C0}"
-  box_row "unchanged ${CD}$already${C0} (already file://)"
+  box_row "rewrote   ${CG}$rewrote${C0}"
+  box_row "unchanged ${CD}$unchanged${C0} (already on file://)"
   [ "$failed" -gt 0 ] && box_row "failed    ${CR}$failed${C0}"
   box_close
-  if [ "$changed" -gt 0 ]; then
+  if [ "$rewrote" -gt 0 ]; then
     printf '\n  %bNext:%b restart your GUI harness (Codex desktop, Claude, Qoder, etc.) so it re-reads .mcp.json.\n' "$CB" "$C0"
     printf '  Each new turn spawns a fresh stdio child, so an in-flight session will still hit the old URL.\n'
   fi
@@ -1192,6 +1185,6 @@ case "${1:-}" in
   localize)  do_localize ;;
   uninstall) do_uninstall ;;
   --verify)  shift; run_caps_noninteractive "$@" ;;
-  -h|--help) banner; printf '\n  Usage: install.sh [install|configure|verify|localize|uninstall]   (no arg = interactive menu)\n         install.sh --verify [caps]   # non-interactive: check installed (or listed) caps\n         install.sh localize            # rewrite .mcp.json to a local file:// URL (sandboxed GUI)\n\n  (No update action — uvx re-resolves the pinned git ref and pulls new commits on each launch.)\n  "localize" is the escape hatch when a sandboxed GUI (Codex desktop, etc.) blocks stdio\n  children from reaching github.com — see docs/en/installation.md → "Sandboxed GUI harnesses".\n\n' ;;
+  -h|--help) banner; printf '\n  Usage: install.sh [install|configure|verify|localize|uninstall]   (no arg = interactive menu)\n         install.sh --verify [caps]   # non-interactive: check installed (or listed) caps\n         install.sh localize            # rewrite .mcp.json to a local file:// URL (sandboxed GUI)\n\n  (No update action — uvx re-resolves the pinned git ref and pulls new commits on each launch.)\n  "localize" is the escape hatch when a sandboxed GUI (Codex desktop, etc.) blocks stdio\n  children from reaching github.com — see docs/en/installation.md → "Sandboxed GUI harnesses".\n  The same flip happens automatically when you run scripts/dev-plugin.sh <cap> for source-iter.\n\n' ;;
   *)         menu ;;
 esac

--- a/scripts/_flip_mcp.py
+++ b/scripts/_flip_mcp.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Rewrite every plugin manifest under the given paths so its uvx --from points at a local
+file:// URL instead of git+https://github.com/QwenLM/Qwen-MM-Plugins.git@main.
+
+Shared between:
+- `scripts/dev-plugin.sh` (dev-time, single cap, optionally adds `--refresh` so uvx rebuilds
+  the local package on every launch)
+- `bash install.sh localize` (production-time, all caps, no `--refresh`)
+
+Driven by env vars:
+- `REPO`            absolute path to the local checkout (required; the script URL-encodes it)
+- `FLIP_ADD_REFRESH` set to "1" to insert `uvx --refresh` at the head of args (dev-time only —
+  production localize must leave it off so the uvx cache is shared with `git+https://` users)
+
+CLI: _flip_mcp.py <manifest.json> [<manifest.json> ...]
+Exits 0 on success, 1 on any IO/JSON error (the caller surfaces per-file status).
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import urllib.parse
+
+GIT_REF = "git+https://github.com/QwenLM/Qwen-MM-Plugins.git@main"
+
+
+def _local_url(repo: str) -> str:
+    # PEP-508 requires percent-escaping inside file:// URLs (spaces, #, %).
+    return "file://" + urllib.parse.quote(pathlib.Path(repo).resolve().as_posix(), safe="/:@!")
+
+
+def _flip(path: str) -> str:
+    """Flip one manifest in place. Returns "ok" / "unchanged" / "skip" / "fail:<reason>"."""
+    p = pathlib.Path(path)
+    if not p.is_file():
+        return "skip:not-found"
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return f"fail:parse:{exc}"
+    changed = False
+    for srv in data.get("mcpServers", {}).values():
+        args = srv.get("args", [])
+        new_args = [a.replace(GIT_REF, _local_url(os.environ["REPO"])) for a in args]
+        if new_args == args and "--refresh" not in args and not os.environ.get("FLIP_ADD_REFRESH"):
+            # Already pointing at this local path AND no refresh requested → idempotent no-op.
+            continue
+        if os.environ.get("FLIP_ADD_REFRESH") == "1" and "--refresh" not in new_args:
+            new_args.insert(0, "--refresh")
+        srv["args"] = new_args
+        changed = True
+    if not changed:
+        return "unchanged"
+    p.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+    return "ok"
+
+
+def main() -> int:
+    if "REPO" not in os.environ:
+        print("_flip_mcp: REPO env var is required", file=sys.stderr)
+        return 1
+    rc = 0
+    for path in sys.argv[1:]:
+        status = _flip(path)
+        print(f"{status}\t{path}")
+        if status.startswith("fail"):
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev-plugin.sh
+++ b/scripts/dev-plugin.sh
@@ -11,6 +11,9 @@
 # --refresh makes uvx rebuild the local package on every launch (a bit slower, but always current).
 # For rapid server-code iteration prefer `claude mcp add <name> -- python3 <server-dir>` instead
 # (no build step at all — see docs/en/local_development.md).
+#
+# The actual manifest-rewriting lives in scripts/_flip_mcp.py — install.sh's `localize`
+# subcommand reuses the same script so the two paths can never drift.
 set -euo pipefail
 repo="$(cd "$(dirname "$0")/.." && pwd)"
 cap="${1:?usage: dev-plugin.sh <cap> [--revert]   (cap = core|video-memory|video-edit|example)}"
@@ -27,23 +30,7 @@ if [ "${2:-}" = "--revert" ]; then
     exit 0
 fi
 
-REPO="$repo" python3 - "${files[@]}" <<'PY'
-import json, os, sys
-
-repo = os.environ["REPO"]
-git_ref = "git+https://github.com/QwenLM/Qwen-MM-Plugins.git@main"
-local = f"file://{repo}"
-for path in sys.argv[1:]:
-    data = json.load(open(path))
-    for srv in data.get("mcpServers", {}).values():
-        args = [a.replace(git_ref, local) for a in srv.get("args", [])]
-        if "--refresh" not in args:
-            args.insert(0, "--refresh")
-        srv["args"] = args
-    with open(path, "w") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
-        f.write("\n")
-PY
+REPO="$repo" FLIP_ADD_REFRESH=1 "$repo/scripts/_flip_mcp.py" "${files[@]}"
 
 echo "✓ flipped $cap manifests → $repo  (file:// + uvx --refresh)"
 echo "  claude plugin marketplace add $repo"


### PR DESCRIPTION
## What

Adds `bash install.sh localize` (and matching docs) to rewrite every
`src/capabilities/<cap>/.mcp.json` to use a `file://<local checkout>` URL
instead of `git+https://github.com/QwenLM/Qwen-MM-Plugins.git@main`.

## Why

Sandboxed GUI harnesses (Codex desktop on macOS / Windows, Claude Desktop,
Qoder, …) spawn each stdio MCP server as a restricted child process that
cannot resolve `github.com` (typical evidence: `codex plugin marketplace
upgrade qwen-mm-plugins` also fails with `Could not resolve host:
github.com`). The default `.mcp.json` ships a
`uvx --from "qwen-mm-plugins[<cap>] @ git+https://github.com/...@main"`
launcher, so the stdio child's first `uvx` invocation needs the network,
fails DNS, exits silently, and the harness reports `unsupported call` for
every `mcp__qwen_mm_plugins_*__*` call — even though `codex mcp list`
shows the servers as `enabled`. Hard to diagnose because every other
indicator looks correct.

Reproduction confirmed in Codex desktop on macOS 26.7.30 with
`codex-cli 0.147.0` after the standard
`curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash`
+ `bash install.sh configure` install.

## What changes

- `install.sh`: new `do_localize()` function + new top-level `localize`
  subcommand + `localize` added to the interactive menu and to the
  headless detection list. Honors `QMP_REPO` (file:// URL or local
  directory; default is the install.sh's own checkout, resolved via
  `BASH_SOURCE` so it works under `curl|bash` and symlink installs).
  Idempotent: re-runs after `git pull` just report "already on file://"
  and rewrite nothing — point the existing file:// at the fresh checkout.
- `docs/en/installation.md` + `docs/zh/installation.md`: new
  "Sandboxed GUI harnesses" / "沙盒化 GUI harness 的网络限制" section with
  symptom / cause / fix / rollback.
- `README.md` + `README.zh.md`: short callout in the install block
  linking to the new docs section; `localize` added to the actions list.

No MCP interface change, no capability code change, no behavior change
for non-sandboxed harnesses (the default `.mcp.json` is still
`git+https://...` until the user runs `localize`).

## Test plan

Verified locally in a headless / non-interactive run of `install.sh`:

- Fresh checkout → `bash install.sh localize` → all 6 `.mcp.json` files
  rewritten, summary `rewrote 6 / unchanged 0`.
- Second run → `unchanged 6 (already on file://)`, no rewrite.
- Third run with `QMP_REPO=file:///explicit/path/src` → still
  `unchanged 6 (already on file://)` (idempotent across different
  file:// paths).
- `QMP_REPO=/path/to/local/clone` (directory) → rewrites to
  `file://<abs path>`.
- `QMP_REPO=git+https://...` → rejected with "must be a file:// URL or
  a local directory".
- `QMP_REPO` pointing at a non-existent path → rejected with
  "non-directory path".
- `bash -n install.sh` clean; `bash install.sh --help` lists `localize`
  in the actions.

End-to-end (sandboxed Codex desktop session): before `localize`, every
`mcp__qwen_mm_plugins_*__*` call returned `unsupported call`; after
`bash install.sh localize` in a local clone + full Codex desktop
restart, all six MCP servers spawned and responded normally —
`qwen_image`, `qwen_tts`, `read_image`, etc. all reachable.

`ruff check .` / `python3 -m pytest tests/` still apply to the parts
unrelated to this PR (this PR only touches `install.sh` and docs); I
ran the local lint/format pass before opening.