### PR TITLE
fix(shared): opt-in raw base64 for input_audio against OpenAI-spec servers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ When OSS creds (`OSS_AK`/`OSS_SK`) are set the VLM gets clipped-video URLs (`cli
 | `ASR_SERVER_URLS` | Comma-separated self-hosted ASR server URLs (transcribe_audio fallback when DashScope fails) |
 | `QWEN_MM_FFMPEG_TIMEOUT` | ffmpeg timeout seconds (default: 120) |
 | `QWEN_MM_CHAT_TIMEOUT` | OpenAI-compatible chat request timeout seconds (default: 600) |
+| `QWEN_MM_AUDIO_RAW_B64` | Send `input_audio` as raw base64 for OpenAI-spec servers like vLLM (default: off = DashScope `data:;base64,…` form) |
 | `QWEN_MM_MAX_TOTAL_FRAMES` | Max frames sampled from a video (default: 600) |
 | `QWEN_MM_CACHE` | Override the cache dir for derived render artifacts (default: OS cache dir) |
 | `GRAPH_MEMORY_PATH` | graph_memory.json path (video-memory MCP server; takes precedence over a passed video path) |

--- a/cookbooks/api/usage.md
+++ b/cookbooks/api/usage.md
@@ -63,6 +63,7 @@ claude plugin install qwen-mm-plugins-api@qwen-mm-plugins
 |-------------|-------------|
 | `DASHSCOPE_API_KEY` | Required — authenticates all Qwen-VL, Qwen-Omni, and Qwen3-ASR requests. |
 | `DASHSCOPE_BASE_URL` | Optional — overrides the OpenAI-compatible endpoint for a proxy or gateway. |
+| `QWEN_MM_AUDIO_RAW_B64` | Optional — set to `1` when `DASHSCOPE_BASE_URL` points at an OpenAI-spec server (e.g. vLLM): audio is sent as raw base64 instead of the DashScope-style `data:;base64,…` form, which such servers reject. Leave unset for DashScope. |
 | `SAM3_SERVER_URL` | Required only for `segmentation` (self-hosted SAM3 server). |
 | `ffmpeg` + `ffprobe` | Required for audio extraction, transcoding, and frame sampling/fitting. |
 | `OSS_AK`, `OSS_SK`, `OSS_ENDPOINT`, `OSS_BUCKET` | Optional — upload oversized local video and pass a signed URL instead of local frame sampling. Install the `oss` extra as well. |

--- a/src/shared/api_omni.py
+++ b/src/shared/api_omni.py
@@ -169,9 +169,19 @@ def omni_audio_part(source: str, *, audio_format: str | None = None) -> dict:
 
     A local file becomes the bare ``data:;base64,…`` form the DashScope docs show for audio (the type
     is carried by ``format``, not a mime prefix).
+
+    That wrapper is DashScope-specific: OpenAI's spec — and vLLM, which implements it — expects
+    ``data`` to be RAW base64. Against a self-hosted server the wrapped form fails base64 decoding
+    ("Incorrect padding"), so ``QWEN_MM_AUDIO_RAW_B64=1`` strips it. The size guard in ``_data_url``
+    still runs either way.
     """
     fmt = (audio_format or Path(source).suffix.lstrip(".") or "wav").lower()
-    data = source if is_url(source) else _data_url(source, "audio/wav", omit_mime=True)
+    if is_url(source):
+        data = source
+    else:
+        data = _data_url(source, "audio/wav", omit_mime=True)
+        if (get_env("QWEN_MM_AUDIO_RAW_B64") or "").lower() in ("1", "true", "yes", "on"):
+            data = data.split(",", 1)[1]
     return {"type": "input_audio", "input_audio": {"data": data, "format": fmt}}
 
 

--- a/tests/test_api_omni.py
+++ b/tests/test_api_omni.py
@@ -7,6 +7,7 @@ dry_run request shape, and output formatting (with the model boundary mocked); a
 test hits the real Omni endpoint only when DASHSCOPE_API_KEY is set.
 """
 
+import base64
 import json
 import os
 import tempfile
@@ -396,6 +397,18 @@ def test_audio_data_url_omits_the_mime_prefix(tmp_path):
     wav.write_bytes(b"RIFF")
     part = api_omni.omni_audio_part(str(wav))
     assert part["input_audio"]["data"].startswith("data:;base64,")
+    assert part["input_audio"]["format"] == "wav"
+
+
+def test_audio_raw_b64_optin_strips_the_wrapper(tmp_path, monkeypatch):
+    # QWEN_MM_AUDIO_RAW_B64 targets OpenAI-spec servers (e.g. vLLM), whose `input_audio.data`
+    # is RAW base64 — the data-URL wrapper fails their decoding with "Incorrect padding"
+    wav = tmp_path / "a.wav"
+    wav.write_bytes(b"RIFF")
+    monkeypatch.setenv("QWEN_MM_AUDIO_RAW_B64", "1")
+    part = api_omni.omni_audio_part(str(wav))
+    assert not part["input_audio"]["data"].startswith("data:")
+    assert base64.b64decode(part["input_audio"]["data"]) == b"RIFF"
     assert part["input_audio"]["format"] == "wav"
 
 


### PR DESCRIPTION
## What changed

`omni_audio_part()` wraps local audio as the bare `data:;base64,…` data URL the DashScope docs show. OpenAI's spec — and vLLM, which implements it — expects `input_audio.data` to be RAW base64, so every audio tool in the omni family fails with `400 Incorrect padding` against a self-hosted server, even though `shared/api_openai.py` explicitly supports those endpoints ("Targets any OpenAI-compatible endpoint", `api_key` falling back to `"EMPTY"`).

This adds an opt-in env var `QWEN_MM_AUDIO_RAW_B64` (parsed like the existing boolean flags: `1/true/yes/on`) that strips the wrapper; the size guard in `_data_url` still runs either way. Default behavior is unchanged, so DashScope requests are not affected. Fixes #8.

## Verification

- `python3 -m pytest tests/test_api_omni.py` → 37 passed, 1 skipped (adds `test_audio_raw_b64_optin_strips_the_wrapper`; the existing default-form test passes unchanged)
- `ruff format --check` / `ruff check` → clean
- Live against vLLM 0.20.0 serving `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8` (this branch, MCP `api` server):
  - without the env var: `omni_asr` → 400 Incorrect padding
  - with `QWEN_MM_AUDIO_RAW_B64=1`: `omni_asr` → 200, correct transcription in 9.7 s
- Live against DashScope compatible-mode (Model Studio International / Singapore, `qwen3.5-omni-plus`): the default `data:;base64,…` form works (200, correct transcription), raw base64 is rejected with 400 `The provided URL does not appear to be valid` — the two servers are strictly incompatible on this field, so a switch is required rather than a format change (measurements in #8). The default code path is unchanged and covered by the existing test.

## Compatibility

- [x] Existing MCP tool names, inputs, and outputs are unchanged, or the change is explained above.
- [x] Tests and documentation were updated where behavior changed.
- [x] No credentials, private media, generated artifacts, or machine-specific configuration are included.
