### PR TITLE
feat(install): support WorkBuddy and CodeBuddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Native multimodal plugins for Qwen models. Make any agent harness multimodal-nat
 
 ## Install
 
-The guided installer supports Claude Code, Codex, Qoder, OpenClaw, Qwen Code, and Gemini CLI. It
-uses each harness's native install command and keeps shared configuration in
-`~/.qwen-mm-plugins/config`.
+The guided installer supports Claude Code, CodeBuddy, Codex, Qoder, OpenClaw, Qwen Code, and Gemini
+CLI. Shared configuration lives in `~/.qwen-mm-plugins/config`.
 
-Manual setup is also documented for DeepSeek Harness, Hermes Agent, opencode, pi, and QwenPaw in
-the [manual harness guide](docs/en/manual_harnesses.md).
+In-app setup for WorkBuddy, QoderWork, and QwenWork, plus manual setup for DeepSeek Harness, Hermes
+Agent, opencode, pi, and QwenPaw, is documented in the
+[other harness guide](docs/en/manual_harnesses.md).
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -10,11 +10,11 @@
 
 ## 安装
 
-引导式安装器支持 Claude Code、Codex、Qoder、OpenClaw、Qwen Code 和 Gemini CLI。它调用各
-harness 的原生安装命令，并通过 `~/.qwen-mm-plugins/config` 共享配置。
+引导式安装器支持 Claude Code、CodeBuddy、Codex、Qoder、OpenClaw、Qwen Code 和 Gemini CLI。
+共享配置位于 `~/.qwen-mm-plugins/config`。
 
-DeepSeek Harness、Hermes Agent、opencode、pi 和 QwenPaw 可参考
-[手动配置其他 Harness](docs/zh/manual_harnesses.md)。
+WorkBuddy、QoderWork 与 QwenWork 的应用内安装，以及 DeepSeek Harness、Hermes Agent、
+opencode、pi 和 QwenPaw 的手动安装方式见[其他 Harness 安装](docs/zh/manual_harnesses.md)。
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash

--- a/docs/en/how_to_add_new_capability.md
+++ b/docs/en/how_to_add_new_capability.md
@@ -82,8 +82,9 @@ Copy `src/capabilities/example/` to `src/capabilities/<yourname>/`, rename `qwen
    where = [..., "src/capabilities/<yourname>"]
    ```
 5. Add the initial version to `plugin-versions.json` and a matching tag-pinned `git-subdir` entry to
-   `.claude-plugin/marketplace.json`. Copy the three harness manifests from an existing capability;
-   server capabilities also carry `.mcp.json`. Run `scripts/check_manifests.py`, then follow
+   the canonical `.claude-plugin/marketplace.json`, which CodeBuddy and WorkBuddy also consume. Copy
+   the three harness manifests from an existing capability; server capabilities also carry
+   `.mcp.json`. Run `scripts/check_manifests.py`, then follow
    [Plugin releases](releasing.md) for the first tag.
 
 `__main__.py` is **copied verbatim** from `src/capabilities/example/` — it infers the import name from the directory name and contains no per-server literals.

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -9,21 +9,18 @@
 | Install a release | `bash install.sh install` | Latest released tag for each capability |
 | Update an existing install | `bash install.sh update` | Current release catalog |
 | Test unpublished code | `bash install.sh local` | Current checkout, including uncommitted changes |
-| Roll back one capability | `QMP_REF=<tag> bash install.sh install` | Exact immutable tag |
+| Roll back one capability | See [Roll back](#roll-back) | Exact immutable tag |
 
 Released installs never follow `main`. To test a branch, check it out and use `local`.
 
 ## Guided installer
 
-The installer supports Claude Code, Codex, Qoder, OpenClaw, Qwen Code, and Gemini CLI. It invokes
-each harness's native install mechanism and stores shared configuration in
+The installer supports Claude Code, CodeBuddy, Codex, Qoder, OpenClaw, Qwen Code, and Gemini CLI. It
+invokes each harness's native installation mechanism and stores shared configuration in
 `~/.qwen-mm-plugins/config`.
 
-DeepSeek Harness is intentionally not in the harness picker. Its `dsh plugin` command manages the
-profile's JavaScript packages, but it does not register an MCP server or install a Skill. Use the
-[manual DeepSeek Harness setup](manual_harnesses.md#deepseek-harness-developer-preview) instead.
-The installer's **Configure** and **Verify** actions remain usable because they do not depend on a
-harness-specific registration command.
+`Qoder` and `Qwen Code` here do not include the separate QoderWork and QwenWork desktop apps. Use
+their [in-app setup](manual_harnesses.md#qoderwork-and-qwenwork-in-app-task) instead.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash
@@ -47,6 +44,7 @@ still need a reload:
 | Harness | Activate the update |
 |---|---|
 | Claude Code | `/reload-plugins`, or restart |
+| CodeBuddy | `/reload-plugins`, or restart |
 | Codex | Start a new task, or restart |
 | Qoder | `/plugins reload`, or restart |
 | OpenClaw | Managed Gateways normally restart automatically; otherwise `openclaw gateway restart` |
@@ -55,7 +53,7 @@ still need a reload:
 
 ### Roll back
 
-Select only the capability named by the tag:
+For guided harnesses that accept a remote tag, select only the capability named by the tag:
 
 ```bash
 QMP_REF=qwen-mm-plugins-search-v1.0.1 bash install.sh install
@@ -106,8 +104,8 @@ detect or notify you about a mismatched update. Run the current installer, choos
 For a linked Skill, use a dedicated checkout per capability/tag because independent tags may point
 to different commits.
 
-Exact configuration examples for each manual harness are in
-[Manual harness setup](manual_harnesses.md).
+In-app steps and exact configuration examples for the other harnesses are in
+[Other harness setup](manual_harnesses.md).
 
 ## Windows (WSL2)
 

--- a/docs/en/manual_harnesses.md
+++ b/docs/en/manual_harnesses.md
@@ -1,18 +1,54 @@
-# Manual harness setup
+# Other harness setup
 
 **English** · [中文](../zh/manual_harnesses.md)
 
-Use the [guided installer](installation.md#guided-installer) when it supports your harness. This
-page is only for registering a Skill and MCP server separately.
+Use the [guided installer](installation.md#guided-installer) by default. This page covers
+the desktop-app UI used by WorkBuddy, QoderWork, and QwenWork, plus direct Skill + MCP registration
+alternatives.
 
-Replace `<cap>` with `core`, `api`, `search`, `video-memory`, `video-edit`, `blender`, or `freecad`.
-`edu-agent` is Skill-only. Use one immutable tag for both the Skill and MCP command:
+## Desktop-app UI
+
+| Product | Installation path |
+|---|---|
+| CodeBuddy | [Guided installer](installation.md#guided-installer) |
+| WorkBuddy | Plugins page below |
+| Qoder | [Guided installer](installation.md#guided-installer) |
+| QoderWork | In-app task below |
+| Qwen Code | [Guided installer](installation.md#guided-installer) |
+| QwenWork | In-app task below |
+
+### WorkBuddy (Plugins page)
+
+WorkBuddy reads the repository's `.claude-plugin/marketplace.json` and installs each plugin as one
+bundle. Open **Plugins**, click **+**, add
+`https://github.com/QwenLM/Qwen-MM-Plugins.git`, then install the desired `qwen-mm-plugins-*`
+plugins from that marketplace. Use the same page to update or uninstall them.
+
+### QoderWork and QwenWork (in-app task)
+
+Start a task in the app, provide the repository URL and desired capability names, and ask it to
+install the complete Skill + MCP bundle. For example:
+
+```text
+Install qwen-mm-plugins-core from https://github.com/QwenLM/Qwen-MM-Plugins.
+Keep its Skill and MCP server on the same released tag, then verify that the MCP tools are online.
+```
+
+Review the resulting entries in the app's Skills and MCP/Connectors panels. To update, repeat the
+task with the current release; to uninstall, remove both entries in those panels. `edu-agent` has
+only a Skill entry.
+
+## Direct Skill + MCP registration
+
+For the direct Skill + MCP registrations below, replace `<cap>` with `core`, `api`, `search`,
+`video-memory`, `video-edit`, `blender`, or `freecad`. `edu-agent` is Skill-only. Use one immutable
+tag for both the Skill and MCP command:
 
 ```text
 qwen-mm-plugins-<cap>-v<version>
 ```
 
-## Claude Code (direct registration)
+### Claude Code
 
 ```bash
 ln -s /path/to/tagged-checkout/src/capabilities/<cap>/skill \
@@ -26,7 +62,7 @@ claude mcp add qwen-mm-plugins-<cap> -- \
 
 For local source, replace the Git package spec with `/path/to/Qwen-MM-Plugins[<cap>]`.
 
-## opencode
+### opencode
 
 Copy the Skill to `~/.config/opencode/skills/qwen-mm-plugins-<cap>` and add:
 
@@ -49,11 +85,12 @@ Copy the Skill to `~/.config/opencode/skills/qwen-mm-plugins-<cap>` and add:
 
 Use `~/.config/opencode/opencode.json` or a project-level `opencode.json`.
 
-## DeepSeek Harness (developer preview)
+### DeepSeek Harness (developer preview)
 
 Validated with `@deepseek-ai/dsh` 0.1.0-rc.6. DSH loads Skills from `$DSH_HOME/skills` (normally
 `~/.dsh/skills`) and connects stdio MCP servers through its bundled `@deepseek-ai/dsh-mcp-client`;
-it currently requires manual registration.
+it currently requires manual registration. The guided installer's **Configure** and **Verify**
+actions remain usable because they do not depend on harness-specific registration.
 
 Install and start DSH once to create the `web` profile:
 
@@ -109,7 +146,7 @@ search remain usable; workflows that depend on media returned by MCP are incompl
 upstream
 [`dsh-mcp-client` limitation](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/mcp/mcp-client/README.md#known-limitations-and-deferred-work).
 
-## Hermes Agent
+### Hermes Agent
 
 Validated with Hermes Agent v0.19.0. The Hermes installation must include MCP support
 (`hermes-agent[mcp]` or `hermes-agent[all]`). Copy the complete Skill directory from the same
@@ -149,7 +186,7 @@ provider receives no image pixels. For `read_video`, timestamps and frame order 
 original multi-frame visual context is lost; rereading individual cached frames does not restore
 that interleaved sequence.
 
-## pi
+### pi
 
 pi supports Skills directly; MCP tools require the community adapter:
 
@@ -177,7 +214,7 @@ Add the server to `~/.config/mcp/mcp.json`:
 }
 ```
 
-## QwenPaw 2.0
+### QwenPaw 2.0
 
 QwenPaw does not consume this repository's plugin manifests. Copy the Skill (symlinks are rejected),
 then enable it:
@@ -211,7 +248,7 @@ Add the server under `mcp.clients` in `~/.qwenpaw/workspaces/default/agent.json`
 }
 ```
 
-## Update a manual install
+### Update
 
 Run the current installer and choose **Update → other (manual / another harness)**. Replace both the
 copied/linked Skill and MCP Git ref with the tag it prints, then reload the harness. The installer

--- a/docs/zh/how_to_add_new_capability.md
+++ b/docs/zh/how_to_add_new_capability.md
@@ -80,9 +80,10 @@ claude plugin install qwen-mm-plugins-<你的能力>@qwen-mm-plugins
    ```toml
    where = [..., "src/capabilities/<yourname>"]
    ```
-5. 在 `plugin-versions.json` 中加入初始版本，并在 `.claude-plugin/marketplace.json` 中加入
-   固定到对应 tag 的 `git-subdir` entry。从现有能力复制三套 harness manifest；有 server 的
-   能力还需 `.mcp.json`。运行 `scripts/check_manifests.py`，再按[插件发布](releasing.md)打首个 tag。
+5. 在 `plugin-versions.json` 中加入初始版本，并在规范的 `.claude-plugin/marketplace.json`
+   （CodeBuddy 与 WorkBuddy 也读取该文件）中加入固定到对应 tag 的 `git-subdir` entry。从现有
+   能力复制三套 harness manifest；有 server 的能力还需 `.mcp.json`。运行
+   `scripts/check_manifests.py`，再按[插件发布](releasing.md)打首个 tag。
 
 `__main__.py` 从 `src/capabilities/example/` **原样复制**——它从目录名推断 import 名，没有任何 per-server 字面量。
 纯 skill 能力不写 `mcpServers`、也没有 `.mcp.json`，但仍保留三套 harness manifest。

--- a/docs/zh/installation.md
+++ b/docs/zh/installation.md
@@ -9,19 +9,18 @@
 | 安装正式版本 | `bash install.sh install` | 各能力最新的已发布 tag |
 | 更新已有安装 | `bash install.sh update` | 当前发布目录 |
 | 测试未发布代码 | `bash install.sh local` | 当前 checkout，包括未提交修改 |
-| 回退单个能力 | `QMP_REF=<tag> bash install.sh install` | 指定的不可变 tag |
+| 回退单个能力 | 见[回退](#回退) | 指定的不可变 tag |
 
 正式安装不会跟随 `main`。测试分支时，先 checkout 该分支，再使用 `local`。
 
 ## 引导式安装器
 
-安装器支持 Claude Code、Codex、Qoder、OpenClaw、Qwen Code 和 Gemini CLI。它调用各 harness
-的原生安装机制，并将共享配置保存在 `~/.qwen-mm-plugins/config`。
+安装器支持 Claude Code、CodeBuddy、Codex、Qoder、OpenClaw、Qwen Code 和 Gemini CLI。
+它调用各 harness 的原生安装机制，并将共享配置保存在
+`~/.qwen-mm-plugins/config`。
 
-DeepSeek Harness 不会出现在 harness 选择列表中。它的 `dsh plugin` 命令只管理 profile 的
-JavaScript 包，不能注册 MCP server 或安装 Skill；请改用
-[DeepSeek Harness 手动配置](manual_harnesses.md)。安装器的
-**Configure** 和 **Verify** 不依赖 harness 专属注册命令，因此仍可使用。
+这里的 `Qoder` 和 `Qwen Code` 不包括独立桌面应用 QoderWork 与 QwenWork；后两者请使用
+[应用内安装](manual_harnesses.md)。
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash
@@ -44,6 +43,7 @@ curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install
 | Harness | 让更新生效 |
 |---|---|
 | Claude Code | 执行 `/reload-plugins`，或重启 |
+| CodeBuddy | 执行 `/reload-plugins`，或重启 |
 | Codex | 新建 task，或重启 |
 | Qoder | 执行 `/plugins reload`，或重启 |
 | OpenClaw | 托管 Gateway 通常自动重启；否则执行 `openclaw gateway restart` |
@@ -52,7 +52,7 @@ curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install
 
 ### 回退
 
-只选择 tag 对应的能力：
+对于支持远程 tag 的引导式 harness，只选择 tag 对应的能力：
 
 ```bash
 QMP_REF=qwen-mm-plugins-search-v1.0.1 bash install.sh install
@@ -100,7 +100,7 @@ uvx --from \
 运行最新安装器，选择 **Update → other (manual / another harness)**，再把两处都更新到脚本打印的
 同一 tag。使用软链接时，每个能力/tag 应使用独立 checkout，因为不同能力 tag 可能指向不同 commit。
 
-各手动 harness 的配置示例见[手动配置其他 Harness](manual_harnesses.md)。
+其他 harness 的应用内步骤和具体配置示例见[其他 Harness 安装](manual_harnesses.md)。
 
 ## Windows（WSL2）
 

--- a/docs/zh/manual_harnesses.md
+++ b/docs/zh/manual_harnesses.md
@@ -1,18 +1,50 @@
-# 手动配置其他 Harness
+# 其他 Harness 安装
 
 [English](../en/manual_harnesses.md) · **中文**
 
-如果引导式安装器支持目标 harness，请优先使用[引导式安装](installation.md#引导式安装器)。本页
-只说明如何分别注册 Skill 与 MCP server。
+默认优先使用[引导式安装](installation.md#引导式安装器)。本页记录 WorkBuddy、QoderWork 与
+QwenWork 的桌面应用 UI，以及直接注册 Skill + MCP 的备选方式。
 
-将 `<cap>` 替换为 `core`、`api`、`search`、`video-memory`、`video-edit`、`blender` 或
-`freecad`。`edu-agent` 是纯 Skill。Skill 与 MCP 命令必须使用同一个不可变 tag：
+## 桌面应用 UI
+
+| 产品 | 安装入口 |
+|---|---|
+| CodeBuddy | [引导式安装器](installation.md#引导式安装器) |
+| WorkBuddy | 下文的插件页面 |
+| Qoder | [引导式安装器](installation.md#引导式安装器) |
+| QoderWork | 下文的应用内任务 |
+| Qwen Code | [引导式安装器](installation.md#引导式安装器) |
+| QwenWork | 下文的应用内任务 |
+
+### WorkBuddy（插件页面）
+
+WorkBuddy 读取仓库的 `.claude-plugin/marketplace.json`，并把每个插件作为一个完整 bundle 安装。
+打开「插件」，点击 `+`，添加 `https://github.com/QwenLM/Qwen-MM-Plugins.git`，再从该市场安装
+所需的 `qwen-mm-plugins-*` 插件。更新或卸载也在同一页面完成。
+
+### QoderWork 与 QwenWork（应用内任务）
+
+在应用中新建任务，提供仓库 URL 和需要的能力名，让它安装完整的 Skill + MCP bundle。例如：
+
+```text
+从 https://github.com/QwenLM/Qwen-MM-Plugins 安装 qwen-mm-plugins-core。
+Skill 与 MCP server 使用同一个已发布 tag，安装后确认 MCP 工具已上线。
+```
+
+完成后，在应用的 Skill 与 MCP/Connector 页面检查对应条目。更新时用当前正式版本重复该任务；
+卸载时在这些页面同时移除两处条目。`edu-agent` 只有 Skill 条目。
+
+## 直接注册 Skill + MCP
+
+对于下文直接注册 Skill + MCP 的 harness，请将 `<cap>` 替换为 `core`、`api`、`search`、
+`video-memory`、`video-edit`、`blender` 或 `freecad`。`edu-agent` 是纯 Skill。Skill 与 MCP
+命令必须使用同一个不可变 tag：
 
 ```text
 qwen-mm-plugins-<cap>-v<version>
 ```
 
-## Claude Code（直接注册）
+### Claude Code
 
 ```bash
 ln -s /path/to/tagged-checkout/src/capabilities/<cap>/skill \
@@ -26,7 +58,7 @@ claude mcp add qwen-mm-plugins-<cap> -- \
 
 使用本地源码时，将 Git 包规格替换为 `/path/to/Qwen-MM-Plugins[<cap>]`。
 
-## opencode
+### opencode
 
 将 Skill 复制到 `~/.config/opencode/skills/qwen-mm-plugins-<cap>`，然后添加：
 
@@ -49,11 +81,12 @@ claude mcp add qwen-mm-plugins-<cap> -- \
 
 配置文件可以是 `~/.config/opencode/opencode.json` 或项目级 `opencode.json`。
 
-## DeepSeek Harness（developer preview）
+### DeepSeek Harness（developer preview）
 
 已使用 `@deepseek-ai/dsh` 0.1.0-rc.6 验证。DSH 从 `$DSH_HOME/skills`（通常为
 `~/.dsh/skills`）加载 Skill，并通过内置 `@deepseek-ai/dsh-mcp-client` 连接 stdio MCP server；
-目前没有自动注册命令，需要手动配置。
+目前没有自动注册命令，需要手动配置。引导式安装器的 **Configure** 和 **Verify** 不依赖
+harness 专属注册，因此仍可使用。
 
 安装并首次启动 DSH，让它创建 `web` profile：
 
@@ -106,7 +139,7 @@ block 替换为 `content discarded`。`vision_chat`、OCR、ASR 和搜索等文�
 返回媒体内容的流程尚不完整。参见上游
 [`dsh-mcp-client` 限制](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/mcp/mcp-client/README.md#known-limitations-and-deferred-work)。
 
-## Hermes Agent
+### Hermes Agent
 
 已使用 Hermes Agent v0.19.0 验证。Hermes 必须安装 MCP 支持（`hermes-agent[mcp]` 或
 `hermes-agent[all]`）。请从 MCP 命令所用的同一不可变 tag 复制完整 Skill 目录。这里不要使用
@@ -143,7 +176,7 @@ block；Hermes 会在本地缓存返回的图片，仅向 provider 发送 `MEDIA
 结构化结果仍可正常使用，但 provider 收不到图片像素。对于 `read_video`，时间戳和帧顺序会保留，
 但原始多帧视觉上下文会丢失；逐帧重新读取缓存图片也无法恢复原来的交错序列。
 
-## pi
+### pi
 
 pi 原生支持 Skill；MCP 工具需要社区 adapter：
 
@@ -171,7 +204,7 @@ pi install npm:pi-mcp-adapter
 }
 ```
 
-## QwenPaw 2.0
+### QwenPaw 2.0
 
 QwenPaw 不读取本仓库的 plugin manifest。请复制 Skill（不支持软链接），然后启用：
 
@@ -204,7 +237,7 @@ qwenpaw skills config
 }
 ```
 
-## 更新手动安装
+### 更新
 
 运行最新安装器并选择 **Update → other (manual / another harness)**。将已复制/链接的 Skill 与
 MCP Git ref 同时替换为脚本打印的 tag，然后重新加载 harness。安装器不会修改未知 harness 的

--- a/install.sh
+++ b/install.sh
@@ -48,11 +48,11 @@ is_skill_only() { case "$CAP_SKILL_ONLY" in *" $1 "*) return 0 ;; *) return 1 ;;
 #   MARKETPLACE harnesses install a bundled skill+MCP plugin via their own `plugin install` verb.
 #   CONFIG harnesses have no plugin marketplace, so we register the MCP server (+ skill) via each
 #   harness's native verb (see install_for). Harnesses that need a hand-edited config + a checkout-copied
-#   skill (DeepSeek Harness, opencode, QwenPaw, pi) stay docs-only (see docs/en/manual_harnesses.md),
-#   not this menu.
+# Harnesses using a native UI or direct Skill/MCP registration stay docs-only (see
+# docs/en/manual_harnesses.md), not this menu.
 # Menus, status, and detection iterate ALL_HARNESSES; install_for/_detect_mask/do_uninstall case per one.
-MP_HARNESSES="claude codex qoder openclaw"          # native plugin marketplace (skill+MCP bundled)
-CFG_HARNESSES="qwen-code gemini"                    # native-verb (extensions install / mcp add + skills install)
+MP_HARNESSES="claude codebuddy codex qoder openclaw" # native plugin marketplace (skill+MCP bundled)
+CFG_HARNESSES="qwen-code gemini"                     # native-verb installs
 ALL_HARNESSES="$MP_HARNESSES $CFG_HARNESSES"
 
 # ── config-field catalog — the ONE place user-settable config vars are declared; do_configure
@@ -166,8 +166,14 @@ trap '_restore_tty; exit 130' INT
 trap '_restore_tty; exit 143' TERM
 
 have()  { command -v "$1" >/dev/null 2>&1; }
-# Friendly harness name → its CLI binary. Only qoder differs (the executable is `qodercli`).
-harness_bin() { case "$1" in qoder) printf 'qodercli' ;; qwen-code) printf 'qwen' ;; *) printf '%s' "$1" ;; esac; }
+# Friendly harness name → its CLI binary.
+harness_bin() {
+  case "$1" in
+    qoder) printf 'qodercli' ;;
+    qwen-code) printf 'qwen' ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
 require_harness() {
   local h=$1 bin; bin=$(harness_bin "$h")
   have "$bin" && return 0
@@ -551,6 +557,21 @@ claude_marketplace_root_from_list() {
   '
 }
 
+codebuddy_marketplace_root_from_list() {
+  local name=$1
+  awk -v wanted="$name" '
+    $0 ~ "\"name\"[[:space:]]*:[[:space:]]*\"" wanted "\"" { found=1; next }
+    found && /"type"[[:space:]]*:/ {
+      if ($0 !~ /"directory"/) { print "remote"; exit }
+      local_source=1
+      next
+    }
+    found && local_source && /"description"[[:space:]]*:/ {
+      sub(/^.*Marketplace from /, ""); sub(/".*$/, ""); print; exit
+    }
+  '
+}
+
 qoder_marketplace_root_from_list() {
   local name=$1
   awk -v wanted="$name" '
@@ -580,7 +601,7 @@ codex_marketplace_source_from_json() {
 }
 
 # configured_marketplace_source <harness> → local root, "remote", or empty when unknown/missing.
-# Used only as a safety check before a stable update: Claude/Codex/Qoder can all retain the local
+# Used only as a safety check before a stable update: Claude/CodeBuddy/Codex/Qoder can retain a local
 # marketplace configured by `install.sh local`, in which case their native update verb keeps using
 # working-tree code rather than the published tags shown in this installer's release index.
 configured_marketplace_source() {
@@ -590,6 +611,9 @@ configured_marketplace_source() {
     claude)
       out=$("$bin" plugin marketplace list 2>/dev/null) || true
       printf '%s\n' "$out" | claude_marketplace_root_from_list "$MARKETPLACE" ;;
+    codebuddy)
+      out=$("$bin" plugin marketplace list 2>/dev/null) || true
+      printf '%s\n' "$out" | codebuddy_marketplace_root_from_list "$MARKETPLACE" ;;
     codex)
       out=$("$bin" plugin marketplace list --json 2>/dev/null) || true
       printf '%s\n' "$out" | codex_marketplace_source_from_json "$MARKETPLACE" ;;
@@ -717,10 +741,35 @@ install_gemini_skill() {  # install_gemini_skill <gemini-bin> <cap>
   return "$rc"
 }
 
+# CodeBuddy can report success after a failed plugin operation. Verify its inventory instead.
+codebuddy_plugins_state() {  # codebuddy_plugins_state <bin> <present|absent> <plugin...>
+  local bin=$1 wanted=$2 out p found failed=0; shift 2
+  out=$("$bin" plugin list 2>/dev/null) || true
+  for p in "$@"; do
+    found=0; printf '%s\n' "$out" | grep -qF -- "${p}@${MARKETPLACE}" && found=1
+    if [ "$wanted" = present ] && [ "$found" = 0 ]; then
+      warn "CodeBuddy did not install ${p}@${MARKETPLACE}"
+      failed=1
+    elif [ "$wanted" = absent ] && [ "$found" = 1 ]; then
+      warn "CodeBuddy still lists ${p}@${MARKETPLACE} after uninstall"
+      failed=1
+    fi
+  done
+  [ "$failed" -eq 0 ]
+}
+
 install_for() {  # install_for <harness> <plugin...>
   local h=$1; shift
   local bin; bin=$(harness_bin "$h")
   local cap failed=0 prompt="Run the $h install commands now (otherwise just print them)?"
+  case "$h" in
+    codebuddy)
+      [ -z "$REPO_REF" ] || {
+        err "the tested $h client cannot install Git marketplace #ref URLs reliably"
+        warn "check out $REPO_REF in a dedicated clone and run 'bash install.sh local' instead"
+        return 1
+      } ;;
+  esac
   is_local_repo "$REPO_URL" && prompt="Install the selected plugins from this checkout into $h now?"
   QMP_DRY=0; confirm "$prompt" y || QMP_DRY=1
   if is_local_repo "$REPO_URL" && [ "$QMP_DRY" = 0 ] && [ "$h" != gemini ]; then
@@ -744,6 +793,28 @@ install_for() {  # install_for <harness> <plugin...>
           run_cmd "$bin" plugin marketplace update "$MARKETPLACE" || return
       fi
       for p in "$@"; do run_cmd "$bin" plugin install "${p}@${MARKETPLACE}" || failed=1; done ;;
+    codebuddy)
+      # `marketplace add` is idempotent but does not switch an existing marketplace between a Git
+      # source and a checkout. Inspect the current source and remove it before such a switch.
+      local current_source desired_source
+      current_source=$(configured_marketplace_source "$h")
+      if is_local_repo "$REPO_URL"; then
+        desired_source=$(cd "${REPO_URL#file://}" 2>/dev/null && pwd -P) || return
+        if [ -n "$current_source" ] && [ "$current_source" != "$desired_source" ]; then
+          warn "switching $MARKETPLACE from $current_source to this checkout"
+          run_cmd "$bin" plugin marketplace remove "$MARKETPLACE" || return
+        fi
+        run_cmd "$bin" plugin marketplace add "$desired_source" || return
+      else
+        if [ -n "$current_source" ] && [ "$current_source" != remote ]; then
+          warn "switching $MARKETPLACE from $current_source to the release catalog"
+          run_cmd "$bin" plugin marketplace remove "$MARKETPLACE" || return
+        fi
+        run_cmd "$bin" plugin marketplace add "${REPO_URL#git+}" || return
+        run_cmd "$bin" plugin marketplace update "$MARKETPLACE" || return
+      fi
+      for p in "$@"; do run_cmd "$bin" plugin install "${p}@${MARKETPLACE}" || failed=1; done
+      if [ "$QMP_DRY" = 0 ]; then codebuddy_plugins_state "$bin" present "$@" || failed=1; fi ;;
     codex)
       # add is idempotent, but on an ALREADY-added marketplace it does NOT refresh the git snapshot,
       # so newly-published capabilities would be missing and their `plugin add` would fail. `upgrade`
@@ -825,7 +896,7 @@ update_for() {
     return 1
   }
   case "$h" in
-    claude|codex|qoder)
+    claude|codebuddy|codex|qoder)
       source=$(configured_marketplace_source "$h")
       if [ -n "$source" ] && [ "$source" != remote ] && is_local_repo "$source"; then
         err "$h currently uses the local marketplace at $source"
@@ -838,6 +909,10 @@ update_for() {
     claude)
       run_cmd "$bin" plugin marketplace update "$MARKETPLACE" || return
       for p in "$@"; do run_cmd "$bin" plugin update "${p}@${MARKETPLACE}" || failed=1; done ;;
+    codebuddy)
+      run_cmd "$bin" plugin marketplace update "$MARKETPLACE" || return
+      for p in "$@"; do run_cmd "$bin" plugin update "${p}@${MARKETPLACE}" || failed=1; done
+      if [ "$QMP_DRY" = 0 ]; then codebuddy_plugins_state "$bin" present "$@" || failed=1; fi ;;
     codex)
       run_cmd "$bin" plugin marketplace upgrade "$MARKETPLACE" || return
       for p in "$@"; do run_cmd "$bin" plugin add "${p}@${MARKETPLACE}" || failed=1; done ;;
@@ -896,6 +971,7 @@ update_for() {
 post_update_hint() {
   case "$1" in
     claude)    warn "already-open Claude Code session: run /reload-plugins (or restart it)" ;;
+    codebuddy) warn "already-open CodeBuddy session: run /reload-plugins (or restart it)" ;;
     codex)     warn "already-open Codex task: start a new task (or restart Codex) to load the updated plugin" ;;
     qoder)     warn "already-open Qoder session: run /plugins reload (or restart it)" ;;
     openclaw)  warn "OpenClaw normally restarts a managed Gateway; otherwise run: openclaw gateway restart" ;;
@@ -907,7 +983,7 @@ post_update_hint() {
 # _detect_mask <harness> → echoes a 0/1 mask (installed?), one char per MP_ITEMS entry.
 # ONE `list` call per harness (the node CLIs are slow to spawn, so we avoid one call per capability),
 # matched against the captured output. Verified per harness on this repo:
-#   - claude / qodercli `list` show installed plugins as "<name>@<marketplace>"
+#   - claude / codebuddy / qodercli `list` show installed plugins as "<name>@<marketplace>"
 #   - codex `plugin list` lists EVERY marketplace plugin with a status column → installed iff the row isn't "not installed"
 #   - openclaw `plugins list` shows installed marketplace plugins by BARE name under a "global:" source root
 # Output is captured before matching so codex's non-zero exit (101) can't trip pipefail; any
@@ -931,10 +1007,10 @@ _detect_mask_cfg() {
 }
 _detect_mask() {
   local h=$1 bin out i id; bin=$(harness_bin "$h")
-  have "$bin" || { printf '%0*d' "${#MP_ITEMS[@]}" 0; return; }
   case "$h" in qwen-code|gemini) _detect_mask_cfg "$h"; return ;; esac
+  have "$bin" || { printf '%0*d' "${#MP_ITEMS[@]}" 0; return; }
   case "$h" in
-    claude|codex) out=$("$bin" plugin  list 2>/dev/null) || true ;;
+    claude|codebuddy|codex) out=$("$bin" plugin list 2>/dev/null) || true ;;
     qoder|openclaw) out=$("$bin" plugins list 2>/dev/null) || true ;;
     *) printf '%0*d' "${#MP_ITEMS[@]}" 0; return ;;
   esac
@@ -1411,7 +1487,11 @@ show_manual() {  # show_manual <install|update|uninstall> [plugin...]
     hr "Manual uninstall / other harness"
     cat <<EOF
 
-  Marketplace installs — use that harness's native verb, e.g.:
+  Desktop-app UI installs:
+    WorkBuddy — open Plugins, select the installed plugin, then choose Manage → Uninstall.
+    QoderWork / QwenWork — remove both the Skill and MCP/Connector entries in the app.
+
+  CLI marketplace installs — use that harness's native verb, e.g.:
     claude   plugin  uninstall qwen-mm-plugins-core@qwen-mm-plugins
     qodercli plugins uninstall qwen-mm-plugins-core@qwen-mm-plugins
 
@@ -1423,6 +1503,10 @@ EOF
     hr "Manual update / other harness"
     browse_repo=${REPO_URL#git+}; browse_repo=${browse_repo%.git}
     cat <<EOF
+
+  Desktop-app UI installs:
+    WorkBuddy — open Plugins and update the installed plugin there.
+    QoderWork / QwenWork — ask a new task to update both Skill and MCP to the current release.
 
   A manual skill copy/symlink and a separately configured MCP server have no shared install
   receipt. This installer cannot safely infer their current versions or edit unknown harness paths.
@@ -1452,14 +1536,21 @@ EOF
     hr "Manual install / other harness"
     cat <<EOF
 
-  A) Plugin marketplace (any Claude-compatible harness — swap the verb per harness):
+  A) Desktop-app UI:
+     WorkBuddy — open Plugins, click +, and add this marketplace address:
+       https://github.com/QwenLM/Qwen-MM-Plugins.git
+     Install the desired qwen-mm-plugins-* entries from that page.
+     QoderWork / QwenWork — start a task, provide the repository URL above, and ask it to install
+     the desired complete Skill + MCP bundle and verify its tools.
+
+  B) CLI plugin marketplace (swap the verb for a compatible harness):
     <harness> plugin marketplace add $(marketplace_source)
     <harness> plugin install       qwen-mm-plugins-core@qwen-mm-plugins
 
      OpenClaw exception: its remote-marketplace policy rejects git-subdir entries. This installer
      maintains $OPENCLAW_MARKETPLACE_DIR and passes that local checkout to OpenClaw instead.
 
-  B) Claude Code — skill + MCP server separately:
+  C) Claude Code — skill + MCP server separately:
     # 1) MCP server (uvx installs deps on first run)
     claude mcp add qwen-mm-plugins-core -- \\
       uvx --from "$(cap_spec core)" qwen-mm-plugins-core
@@ -1468,7 +1559,7 @@ EOF
     ln -s /path/to/Qwen-MM-Plugins/src/capabilities/core/skill \\
       ~/.claude/skills/qwen-mm-plugins-core
 
-  C) Config-file harnesses (DeepSeek Harness · opencode · pi · QwenPaw) — register the MCP server +
+  D) Config-file harnesses (DeepSeek Harness · opencode · pi · QwenPaw) — register the MCP server +
      skill in the harness's own config; exact blocks are in docs/en/manual_harnesses.md. DSH has no
      native Skill/MCP install verb and uses its profile Cordis patch. pi in brief:
     cp -r /path/to/Qwen-MM-Plugins/src/capabilities/core/skill ~/.pi/agent/skills/qwen-mm-plugins-core
@@ -1652,6 +1743,8 @@ do_uninstall() {
     plugin_rc=0
     case "$h" in
       claude)   run_cmd "$bin" plugin  uninstall "qwen-mm-plugins-${p}@${MARKETPLACE}" || plugin_rc=1 ;;
+      codebuddy) run_cmd "$bin" plugin uninstall "qwen-mm-plugins-${p}@${MARKETPLACE}" || plugin_rc=1
+                 if [ "$QMP_DRY" = 0 ]; then codebuddy_plugins_state "$bin" absent "qwen-mm-plugins-${p}" || plugin_rc=1; fi ;;
       codex)    run_cmd "$bin" plugin  remove    "qwen-mm-plugins-${p}@${MARKETPLACE}" || plugin_rc=1 ;;
       qoder)    run_cmd "$bin" plugins uninstall "qwen-mm-plugins-${p}@${MARKETPLACE}" || plugin_rc=1 ;;
       openclaw) run_cmd "$bin" plugins uninstall "qwen-mm-plugins-${p}" --force || plugin_rc=1 ;;  # --force: openclaw prompts otherwise
@@ -1664,8 +1757,8 @@ do_uninstall() {
     esac
     if [ "$plugin_rc" = 0 ]; then removed="$removed $p"; else failed=1; fi
   done
-  # claude tracks the marketplace separately; drop it only when nothing is left installed
-  if [ "$h" = claude ] && [ "$remains" = 0 ] && [ "$failed" = 0 ]; then
+  # Claude and CodeBuddy track the marketplace separately; drop it when nothing remains.
+  if { [ "$h" = claude ] || [ "$h" = codebuddy ]; } && [ "$remains" = 0 ] && [ "$failed" = 0 ]; then
     run_cmd "$bin" plugin marketplace remove "$MARKETPLACE" || failed=1
   fi
 

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -334,6 +334,7 @@ do_verify
     ("harness", "expected"),
     [
         ("claude", "claude plugin install qwen-mm-plugins-core@qwen-mm-plugins"),
+        ("codebuddy", "codebuddy plugin install qwen-mm-plugins-core@qwen-mm-plugins"),
         ("codex", "codex plugin add qwen-mm-plugins-core@qwen-mm-plugins"),
         ("qoder", "qodercli plugins install qwen-mm-plugins-core@qwen-mm-plugins"),
         ("openclaw", "openclaw plugins install qwen-mm-plugins-core --marketplace"),
@@ -353,6 +354,61 @@ def test_local_install_uses_each_harness_native_command(tmp_path, harness, expec
     assert str(checkout) in result.stdout
 
 
+def test_harness_catalog_includes_codebuddy_but_not_ui_only_desktop_apps():
+    result = _bash('printf "%s\n%s\n" "$MP_HARNESSES" "$CFG_HARNESSES"')
+    assert result.returncode == 0, result.stderr
+    marketplace, config = result.stdout.splitlines()
+    assert "codebuddy" in marketplace.split()
+    for desktop_app in ("workbuddy", "qoderwork", "qwenwork"):
+        assert desktop_app not in marketplace.split()
+        assert desktop_app not in config.split()
+
+
+def test_codebuddy_rejects_broken_marketplace_ref_urls():
+    result = _bash("REPO_REF=qwen-mm-plugins-core-v1.0.1; install_for codebuddy qwen-mm-plugins-core")
+    assert result.returncode == 1
+    assert "tested codebuddy client cannot install Git marketplace #ref URLs reliably" in result.stdout
+
+
+def test_codebuddy_marketplace_parser_distinguishes_local_and_remote():
+    local_listing = """[
+  {
+    "name": "qwen-mm-plugins",
+    "type": "directory",
+    "description": "Marketplace from /tmp/checkout with spaces"
+  }
+]"""
+    remote_listing = """[
+  {
+    "name": "qwen-mm-plugins",
+    "type": "git",
+    "description": "Marketplace from https://example.test/repo.git"
+  }
+]"""
+    result = _bash(
+        'printf "%s\n" "$LOCAL_LISTING" | codebuddy_marketplace_root_from_list qwen-mm-plugins; '
+        'printf "%s\n" "$REMOTE_LISTING" | codebuddy_marketplace_root_from_list qwen-mm-plugins',
+        LOCAL_LISTING=local_listing,
+        REMOTE_LISTING=remote_listing,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["/tmp/checkout with spaces", "remote"]
+
+
+def test_codebuddy_install_checks_inventory_when_cli_falsely_returns_zero(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    cli = fake_bin / "codebuddy"
+    cli.write_text("#!/usr/bin/env bash\nexit 0\n")
+    cli.chmod(0o755)
+    result = _bash(
+        "confirm() { return 0; }; install_for codebuddy qwen-mm-plugins-core",
+        PATH=f"{fake_bin}:{os.environ['PATH']}",
+    )
+    assert result.returncode == 1
+    assert "CodeBuddy did not install qwen-mm-plugins-core@qwen-mm-plugins" in result.stdout
+
+
 @pytest.mark.parametrize(
     ("harness", "expected"),
     [
@@ -361,6 +417,13 @@ def test_local_install_uses_each_harness_native_command(tmp_path, harness, expec
             (
                 "claude plugin marketplace update qwen-mm-plugins",
                 "claude plugin update qwen-mm-plugins-core@qwen-mm-plugins",
+            ),
+        ),
+        (
+            "codebuddy",
+            (
+                "codebuddy plugin marketplace update qwen-mm-plugins",
+                "codebuddy plugin update qwen-mm-plugins-core@qwen-mm-plugins",
             ),
         ),
         (
@@ -464,6 +527,7 @@ def test_gemini_skill_checkout_uses_same_stable_tag():
     ("harness", "expected"),
     [
         ("claude", "/reload-plugins"),
+        ("codebuddy", "/reload-plugins"),
         ("codex", "start a new task"),
         ("qoder", "/plugins reload"),
         ("openclaw", "openclaw gateway restart"),


### PR DESCRIPTION
## Why

WorkBuddy and CodeBuddy Code users need the same installable skill and MCP capability flow that the existing supported harnesses provide.

## What Changed

- Add a CodeBuddy marketplace catalog kept in lockstep with the Claude catalog.
- Add CodeBuddy CLI installation and atomic WorkBuddy settings integration to the guided installer.
- Cover the integrations with installer and manifest consistency tests, then document setup and local-checkout constraints in English and Chinese.