### PR TITLE
feat(search): support multiple search backends

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Qwen multimodal understanding plugins — Agent Skills + MCP servers",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "plugins": [
     {
@@ -35,9 +35,9 @@
         "source": "git-subdir",
         "url": "https://github.com/QwenLM/Qwen-MM-Plugins.git",
         "path": "src/capabilities/search",
-        "ref": "qwen-mm-plugins-search-v1.0.1"
+        "ref": "qwen-mm-plugins-search-v1.0.2"
       },
-      "description": "Web + reverse-image search to confirm facts: web search, page extraction, reverse image search as MCP tools; currently supports Serper."
+      "description": "Web search and page extraction via Serper, Exa, or Tavily, plus Serper Lens reverse-image search as MCP tools."
     },
     {
       "name": "qwen-mm-plugins-video-memory",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ install name is `qwen-mm-plugins-<capability>`.
 |---|---|---|---|
 | `core` | Read images and video; visualize documents, code, data, 3D files, and more | No API key; ffmpeg for audio/video; format-specific apps as needed | [Cookbook](cookbooks/core/usage.md) |
 | `api` | Qwen VL/Omni vision, OCR, grounding, ASR, segmentation, and audio-video understanding | DashScope; ffmpeg for local audio/video | [Cookbook](cookbooks/api/usage.md) |
-| `search` | Web search, page extraction, and reverse-image search | Serper API key | [Cookbook](cookbooks/search/usage.md) |
+| `search` | Web search, page extraction, and reverse-image search | Serper, Exa, or Tavily key; image search requires Serper | [Cookbook](cookbooks/search/usage.md) |
 | `video-memory` | Build hierarchical memory for long-video QA | DashScope; ffmpeg/ffprobe for builds | [Cookbook](cookbooks/video-memory/usage.md) |
 | `video-edit` | Image, video, and audio generation with editing workflows | DashScope; ffmpeg + Node/Chromium for full edits | [Cookbook](cookbooks/video-edit/usage.md) |
 | `blender` | Model, texture, light, and render in Blender | Blender; Xvfb on headless Linux | [Cookbook](cookbooks/blender/usage.md) |

--- a/README.zh.md
+++ b/README.zh.md
@@ -35,7 +35,7 @@ curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install
 |---|---|---|---|
 | `core` | 读取图片和视频；可视化文档、代码、数据、3D 文件等 | 无需 API key；音视频需要 ffmpeg；其他格式按需安装应用 | [Cookbook](cookbooks/core/usage.md) |
 | `api` | Qwen VL/Omni 视觉理解、OCR、grounding、ASR、分割与音视频理解 | DashScope；本地音视频需要 ffmpeg | [Cookbook](cookbooks/api/usage.md) |
-| `search` | 网页搜索、页面抽取和反向图像搜索 | Serper API key | [Cookbook](cookbooks/search/usage.md) |
+| `search` | 网页搜索、页面抽取和反向图像搜索 | Serper、Exa 或 Tavily key；反向图搜需要 Serper | [Cookbook](cookbooks/search/usage.md) |
 | `video-memory` | 为长视频问答构建层次化记忆 | DashScope；构建需要 ffmpeg/ffprobe | [Cookbook](cookbooks/video-memory/usage.md) |
 | `video-edit` | 图片、视频、音频生成与剪辑工作流 | DashScope；完整剪辑需要 ffmpeg、Node/Chromium | [Cookbook](cookbooks/video-edit/usage.md) |
 | `blender` | 在 Blender 中完成建模、材质、灯光与渲染 | Blender；无界面 Linux 需要 Xvfb | [Cookbook](cookbooks/blender/usage.md) |

--- a/cookbooks/search/usage.md
+++ b/cookbooks/search/usage.md
@@ -1,7 +1,7 @@
 # Cookbook — Qwen-MM-Plugins Search
 
-`qwen-mm-plugins-search` verifies facts that cannot be established from media alone. It uses Serper
-for Google web results, page extraction, and Google Lens reverse-image search.
+`qwen-mm-plugins-search` verifies facts that cannot be established from media alone. Web search and
+page extraction support Serper, Exa, and Tavily; reverse-image search always uses Serper Lens.
 
 Use [`core`](../core/usage.md) to save a clear image or video frame first. Use
 [`api`](../api/usage.md) when the task needs model-based OCR, grounding, or visual reasoning before
@@ -32,8 +32,12 @@ claude plugin install qwen-mm-plugins-core@qwen-mm-plugins    # save local views
 claude plugin install qwen-mm-plugins-search@qwen-mm-plugins
 ```
 
-Set `SERPER_API_KEY` through the installer's **Configure** action, an environment variable, or
-`~/.qwen-mm-plugins/config`. Environment variables take precedence. `core` itself needs no key.
+Set one or more of `SERPER_API_KEY`, `TAVILY_API_KEY`, and `EXA_API_KEY`. With
+`QWEN_MM_SEARCH_BACKEND` unset or set to `auto`, text tools choose the first configured provider in
+that order. Set the selector to `serper`, `tavily`, or `exa` to pin a provider; an explicit choice
+does not fall back when its key is missing. `image_search` ignores the selector and always requires
+`SERPER_API_KEY`. Use the installer's **Configure** action, an environment variable, or
+`~/.qwen-mm-plugins/config`; environment variables take precedence. `core` itself needs no key.
 
 ---
 

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -125,10 +125,18 @@ are credentials and system applications.
 | Variable | Used by |
 |---|---|
 | `DASHSCOPE_API_KEY` | Cloud media APIs, generation, and video-memory builds |
-| `SERPER_API_KEY` | Web, extraction, and reverse-image search when using Serper |
+| `QWEN_MM_SEARCH_BACKEND` | Optional text-search override: `serper`, `tavily`, `exa`, or `auto` |
+| `SERPER_API_KEY` | Serper web search/extraction and all reverse-image search |
+| `EXA_API_KEY` | Exa web search and extraction |
+| `TAVILY_API_KEY` | Tavily web search and extraction |
 
 Native `core` file reading needs no API key. Set values through the installer's **Configure** action,
 the shell environment, or `~/.qwen-mm-plugins/config`; environment variables take precedence.
+With the selector unset or set to `auto`, text search uses the first configured key in this fixed
+order: Serper, Tavily, Exa. An explicitly selected provider is strict and reports a missing-key
+error instead of falling back.
+`image_search` always uses Serper Lens, independently of `QWEN_MM_SEARCH_BACKEND`, and raises an
+error when `SERPER_API_KEY` is unavailable.
 
 ### Common system tools
 

--- a/docs/zh/installation.md
+++ b/docs/zh/installation.md
@@ -117,10 +117,18 @@ wsl --install -d Ubuntu
 | 变量 | 用途 |
 |---|---|
 | `DASHSCOPE_API_KEY` | 云端媒体 API、内容生成和 video-memory 构建 |
-| `SERPER_API_KEY` | 使用 Serper 时的网页、页面抽取和反向图像搜索 |
+| `QWEN_MM_SEARCH_BACKEND` | 可选的文本搜索覆盖项：`serper`、`tavily`、`exa` 或 `auto` |
+| `SERPER_API_KEY` | Serper 网页搜索/抽取，以及所有反向图像搜索 |
+| `EXA_API_KEY` | Exa 网页搜索和页面抽取 |
+| `TAVILY_API_KEY` | Tavily 网页搜索和页面抽取 |
 
 本地 `core` 文件读取无需 API key。可通过安装器的 **Configure**、shell 环境变量或
 `~/.qwen-mm-plugins/config` 设置；环境变量优先。
+未设置该变量或设为 `auto` 时，文本搜索按固定顺序选择第一个已配置 key 的后端：
+Serper、Tavily、Exa。显式指定后端时会严格使用该后端；如果缺少对应 key，则直接报错，
+不会回退。
+`image_search` 独立于 `QWEN_MM_SEARCH_BACKEND`，始终使用 Serper Lens；缺少
+`SERPER_API_KEY` 时会直接报错。
 
 ### 常用系统工具
 

--- a/install.sh
+++ b/install.sh
@@ -29,10 +29,10 @@ LOCAL_REPO_ROOT=''
 CAP_ITEMS=(core api search video-memory video-edit blender freecad edu-agent)
 # Latest stable plugin versions, in exactly the same order as CAP_ITEMS. Keep this release index in
 # sync with plugin-versions.json; scripts/check_manifests.py and tests/test_install_sh.py enforce it.
-CAP_VERSIONS=(1.0.1 1.0.1 1.0.1 1.0.1 1.0.1 1.0.1 1.0.1 1.0.1)
+CAP_VERSIONS=(1.0.1 1.0.1 1.0.2 1.0.1 1.0.1 1.0.1 1.0.1 1.0.1)
 CAP_DESC=("read/visualize any local file — images, video, docs, 3D"
           "cloud media APIs by model family: VL (vision_chat/ocr/grounding), Omni A/V, ASR, segmentation"
-          "web + reverse-image search (Serper) to confirm facts"
+          "web search/extraction (Serper, Exa, Tavily) + Serper reverse-image search"
           "hierarchical graph memory for long-video QA"
           "video-edit + image/video/audio generation"
           "drive a running Blender: 3D modeling / materials / render (thin client)"
@@ -63,7 +63,10 @@ ALL_HARNESSES="$MP_HARNESSES $CFG_HARNESSES"
 CONFIG_SPEC=(
   "DASHSCOPE_API_KEY|1|cred||vision, OCR, grounding, ASR, generation, memory builds"
   "DASHSCOPE_BASE_URL|0|cred|DashScope compat URL|override the DashScope OpenAI-compatible base URL"
-  "SERPER_API_KEY|1|cred||web_search / web_extractor / image_search"
+  "QWEN_MM_SEARCH_BACKEND|0|cred|auto|text search backend (auto: serper > tavily > exa; or choose one)"
+  "SERPER_API_KEY|1|cred||Serper web_search / web_extractor and Serper-only image_search"
+  "EXA_API_KEY|1|cred||Exa web_search / web_extractor"
+  "TAVILY_API_KEY|1|cred||Tavily web_search / web_extractor"
   "SAM3_SERVER_URL|0|cred||segmentation SAM3 server URL"
   "ASR_SERVER_URLS|0|cred||self-hosted ASR fallback URLs (comma-separated)"
   "QWEN_MM_CACHE|0|dirs|OS cache dir|cache dir for derived render artifacts"

--- a/plugin-versions.json
+++ b/plugin-versions.json
@@ -1,5 +1,5 @@
 {
-  "distribution_version": "1.0.1",
+  "distribution_version": "1.0.2",
   "tag_format": "qwen-mm-plugins-{cap}-v{version}",
   "plugins": {
     "api": "1.0.1",
@@ -7,7 +7,7 @@
     "core": "1.0.1",
     "edu-agent": "1.0.1",
     "freecad": "1.0.1",
-    "search": "1.0.1",
+    "search": "1.0.2",
     "video-edit": "1.0.1",
     "video-memory": "1.0.1"
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ Issues = "https://github.com/QwenLM/Qwen-MM-Plugins/issues"
 [project.optional-dependencies]
 # capability extras — compose via the profiles below
 api = ["openai", "dashscope", "requests"]     # vision_chat / ocr / grounding / segmentation / ASR
-search = ["requests"]                          # web_search / web_extractor / image_search (Serper)
+search = ["requests"]                          # search via Serper / Exa / Tavily; reverse-image via Serper
 # viz = the full visualize stack — a `core` install then renders every format out of the box.
 viz = [
     "pypdfium2", "resvg-py", "lxml",          # PDF raster+text (pypdfium2) / SVG (resvg) / DrawIO / LaTeX

--- a/src/capabilities/search/.claude-plugin/plugin.json
+++ b/src/capabilities/search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qwen-mm-plugins-search",
-  "version": "1.0.1",
-  "description": "Qwen-MM-Plugins search — web + reverse-image search to confirm facts: web search, page extraction, reverse image search, exposed as an MCP server; currently supports Serper.",
+  "version": "1.0.2",
+  "description": "Qwen-MM-Plugins search — web search and page extraction via Serper, Exa, or Tavily, plus Serper Lens reverse-image search, exposed as an MCP server.",
   "skills": [
     "./skill"
   ],
@@ -10,7 +10,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "qwen-mm-plugins[search] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-search-v1.0.1",
+        "qwen-mm-plugins[search] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-search-v1.0.2",
         "qwen-mm-plugins-search"
       ]
     }

--- a/src/capabilities/search/.codex-plugin/plugin.json
+++ b/src/capabilities/search/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qwen-mm-plugins-search",
-  "version": "1.0.1",
-  "description": "Qwen-MM-Plugins search — web + reverse-image search to confirm facts: web search, page extraction, reverse image search, exposed as an MCP server; currently supports Serper.",
+  "version": "1.0.2",
+  "description": "Qwen-MM-Plugins search — web search and page extraction via Serper, Exa, or Tavily, plus Serper Lens reverse-image search, exposed as an MCP server.",
   "skills": "./skill",
   "mcpServers": "./.mcp.json"
 }

--- a/src/capabilities/search/.mcp.json
+++ b/src/capabilities/search/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "qwen-mm-plugins[search] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-search-v1.0.1",
+        "qwen-mm-plugins[search] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-search-v1.0.2",
         "qwen-mm-plugins-search"
       ]
     }

--- a/src/capabilities/search/.qoder-plugin/plugin.json
+++ b/src/capabilities/search/.qoder-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "qwen-mm-plugins-search",
   "displayName": "Qwen MM Plugins Search",
-  "version": "1.0.1",
-  "description": "Web + reverse-image search to confirm facts: web search, page extraction, reverse image search as MCP tools; currently supports Serper.",
+  "version": "1.0.2",
+  "description": "Web search and page extraction via Serper, Exa, or Tavily, plus Serper Lens reverse-image search as MCP tools.",
   "skills": "./skill",
   "mcp": ".mcp.json"
 }

--- a/src/capabilities/search/qwen_mm_plugins_search/__init__.py
+++ b/src/capabilities/search/qwen_mm_plugins_search/__init__.py
@@ -1,21 +1,24 @@
 """Qwen-MM-Plugins search: web + reverse-image search for confirming facts.
 
 A pure-tools MCP server. Each module under ``tools/`` exports ``TOOL`` + ``handle`` and is
-auto-discovered by the framework. All tools call the Serper API (google.serper.dev) via the
-package-local ``serper`` client: web_search (text results), web_extractor (page content),
-image_search (reverse image / lens). Needs SERPER_API_KEY.
+auto-discovered by the framework. ``web_search`` and ``web_extractor`` support Serper, Exa,
+and Tavily through the package-local backend adapters. ``image_search`` uses Serper Lens.
 """
 
 from mcp_framework import build_registry
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 # Auto-discover tools from tools/.
 SPECS, get_handler, list_tools = build_registry(__name__, ["tools"])
 
 USAGE_NOTE = (
-    "Web + reverse-image search (Serper — needs SERPER_API_KEY): web_search finds facts, "
-    "web_extractor reads a page in depth, image_search reverse-searches a frame to identify an "
-    "entity. Grab frames with qwen-mm-plugins-core's save_view first; cross-check appearance with "
-    "qwen-mm-plugins-api's vision_chat."
+    "Web search + page extraction (Serper / Exa / Tavily) and reverse-image search "
+    "(Serper Lens): web_search finds facts, web_extractor reads a page in depth, and "
+    "text search auto-selects configured keys in Serper / Tavily / Exa order unless "
+    "QWEN_MM_SEARCH_BACKEND pins one provider. "
+    "image_search reverse-searches a frame to identify an entity and always uses SERPER_API_KEY, "
+    "independently of the text backend. Grab frames with "
+    "qwen-mm-plugins-core's save_view first; "
+    "cross-check appearance with qwen-mm-plugins-api's vision_chat."
 )

--- a/src/capabilities/search/qwen_mm_plugins_search/backends.py
+++ b/src/capabilities/search/qwen_mm_plugins_search/backends.py
@@ -1,0 +1,211 @@
+"""Pluggable text-search and page-extraction backends.
+
+The public MCP tool schemas stay provider-neutral. ``QWEN_MM_SEARCH_BACKEND``
+can pin the transport at call time; otherwise configured keys are discovered in
+the order Serper, Tavily, Exa. This module normalizes provider responses into
+the legacy Serper-shaped fields consumed by the tool formatters.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+SUPPORTED_BACKENDS = ("serper", "exa", "tavily")
+AUTO_BACKEND_PRIORITY = ("serper", "tavily", "exa")
+BACKEND_KEY_ENVS = {
+    "serper": "SERPER_API_KEY",
+    "exa": "EXA_API_KEY",
+    "tavily": "TAVILY_API_KEY",
+}
+
+EXA_BASE = "https://api.exa.ai"
+TAVILY_BASE = "https://api.tavily.com"
+DEFAULT_TIMEOUT = 60
+DEFAULT_MAX_RETRIES = 5
+SEARCH_SNIPPET_LIMIT = 1000
+EXTRACT_CONTENT_LIMIT = 8000
+_BACKOFF_CAP_SECONDS = 10
+
+
+def resolve_backend() -> str:
+    """Return an explicit backend, or auto-select the first configured key."""
+    from shared.env import get_env
+
+    selected = (get_env("QWEN_MM_SEARCH_BACKEND") or "").strip().lower()
+    if selected and selected != "auto":
+        return selected
+
+    for backend in AUTO_BACKEND_PRIORITY:
+        if get_env(BACKEND_KEY_ENVS[backend]):
+            return backend
+
+    # Preserve the long-standing missing-key error when no provider is configured.
+    return "serper"
+
+
+def backend_error(backend: str) -> str | None:
+    """Return a user-facing error for an unsupported backend, otherwise ``None``."""
+    if backend in SUPPORTED_BACKENDS:
+        return None
+    choices = ", ".join(SUPPORTED_BACKENDS)
+    return f"unsupported search backend {backend!r}. Set QWEN_MM_SEARCH_BACKEND to one of: {choices}."
+
+
+def resolve_api_key(arguments: dict[str, Any], backend: str) -> str:
+    """Explicit ``api_key`` argument, then the selected backend's environment key."""
+    from shared.env import get_env
+
+    explicit = arguments.get("api_key")
+    env_name = BACKEND_KEY_ENVS.get(backend)
+    return explicit or (get_env(env_name) if env_name else None) or ""
+
+
+def missing_key_error(backend: str) -> str:
+    """Return the missing-key message for a validated backend name."""
+    env_name = BACKEND_KEY_ENVS[backend]
+    return f"no API key for {backend}. Set {env_name} or pass api_key."
+
+
+def _post_json(
+    url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+    *,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict[str, Any] | None:
+    """POST JSON with the same transient retry policy used by the Serper client."""
+    import requests
+
+    from shared.retry import retry_call
+
+    request_headers = {"Content-Type": "application/json", **headers}
+
+    def _post() -> dict[str, Any]:
+        response = requests.post(url, json=payload, headers=request_headers, timeout=timeout)
+        response.raise_for_status()
+        return response.json()
+
+    def _retryable(error: Exception) -> bool:
+        response = getattr(error, "response", None)
+        status = getattr(response, "status_code", None)
+        return not isinstance(status, int) or status in (408, 429) or status >= 500
+
+    try:
+        return retry_call(
+            _post,
+            attempts=max_retries,
+            mode="exp",
+            cap=_BACKOFF_CAP_SECONDS,
+            should_retry=_retryable,
+            on_exhausted="none",
+            log=log,
+        )
+    except requests.HTTPError:
+        return None
+
+
+def _normalized_result(
+    doc: dict[str, Any],
+    *,
+    url_key: str,
+    snippet_key: str,
+    date_key: str,
+) -> dict[str, Any]:
+    """Map one provider result onto the legacy formatter's common fields."""
+    return {
+        "link": doc.get(url_key, ""),
+        "title": doc.get("title") or "N/A",
+        "snippet": doc.get(snippet_key) or "N/A",
+        "date": doc.get(date_key) or "N/A",
+    }
+
+
+def search_text(query: str, backend: str, api_key: str) -> list[dict[str, Any]]:
+    """Search one query and return normalized ``link/title/snippet/date`` results."""
+    if backend == "serper":
+        from qwen_mm_plugins_search.serper import post_serper
+
+        data = post_serper(
+            "search",
+            {"q": query, "gl": "us", "hl": "en", "location": "United States", "num": 10},
+            api_key,
+            max_retries=10,
+        )
+        return [
+            _normalized_result(doc, url_key="link", snippet_key="snippet", date_key="date")
+            for doc in (data or {}).get("organic", [])
+        ]
+
+    if backend == "exa":
+        data = _post_json(
+            f"{EXA_BASE}/search",
+            {
+                "query": query,
+                "numResults": 10,
+                "contents": {"text": {"maxCharacters": SEARCH_SNIPPET_LIMIT}},
+            },
+            {"x-api-key": api_key},
+            max_retries=10,
+        )
+        return [
+            _normalized_result(doc, url_key="url", snippet_key="text", date_key="publishedDate")
+            for doc in (data or {}).get("results", [])
+        ]
+
+    if backend == "tavily":
+        data = _post_json(
+            f"{TAVILY_BASE}/search",
+            {"query": query, "search_depth": "basic", "max_results": 10, "include_answer": False},
+            {"Authorization": f"Bearer {api_key}"},
+            max_retries=10,
+        )
+        return [
+            _normalized_result(doc, url_key="url", snippet_key="content", date_key="published_date")
+            for doc in (data or {}).get("results", [])
+        ]
+
+    raise ValueError(backend_error(backend))
+
+
+def extract_page(url: str, backend: str, api_key: str) -> str:
+    """Extract one page as markdown/text, or return an error/empty-content note."""
+    if backend == "serper":
+        from qwen_mm_plugins_search.serper import post_serper
+
+        data = post_serper("scrape", {"url": url, "includeMarkdown": True}, api_key, max_retries=3)
+        if data is None:
+            return f"Error scraping {url}"
+        return data.get("markdown") or data.get("text") or "No content extracted."
+
+    if backend == "exa":
+        data = _post_json(
+            f"{EXA_BASE}/contents",
+            {"urls": [url], "text": {"maxCharacters": EXTRACT_CONTENT_LIMIT}},
+            {"x-api-key": api_key},
+            max_retries=3,
+        )
+        statuses = (data or {}).get("statuses", [])
+        if statuses and statuses[0].get("status") != "success":
+            return f"Error scraping {url}"
+        results = (data or {}).get("results", [])
+        if not results:
+            return f"Error scraping {url}"
+        return results[0].get("text") or "No content extracted."
+
+    if backend == "tavily":
+        data = _post_json(
+            f"{TAVILY_BASE}/extract",
+            {"urls": [url], "format": "markdown"},
+            {"Authorization": f"Bearer {api_key}"},
+            max_retries=3,
+        )
+        results = (data or {}).get("results", [])
+        if not results:
+            return f"Error scraping {url}"
+        return results[0].get("raw_content") or "No content extracted."
+
+    raise ValueError(backend_error(backend))

--- a/src/capabilities/search/qwen_mm_plugins_search/tools/web_extractor.py
+++ b/src/capabilities/search/qwen_mm_plugins_search/tools/web_extractor.py
@@ -1,4 +1,4 @@
-"""MCP tool: web page content extraction via the public Serper scrape API."""
+"""MCP tool: web page extraction through the configured search backend."""
 
 from __future__ import annotations
 
@@ -12,7 +12,10 @@ CONTENT_LIMIT = 8000  # chars of scraped page kept per URL
 class WebExtractorArgs(BaseModel):
     urls: list[str] = Field(description="URLs to crawl and extract content from.", min_length=1)
     goal: str = Field(description="What information to extract or focus on.")
-    api_key: Optional[str] = Field(default=None, description="Serper API key (defaults to SERPER_API_KEY).")
+    api_key: Optional[str] = Field(
+        default=None,
+        description="API key for the selected search backend (defaults to its backend-specific environment key).",
+    )
 
 
 TOOL: dict[str, Any] = {
@@ -25,18 +28,14 @@ TOOL: dict[str, Any] = {
 }
 
 
-def _scrape_page(url: str, api_key: str) -> str:
-    """Scrape a URL via Serper; returns its markdown/text, or an error/empty note."""
-    from qwen_mm_plugins_search.serper import post_serper
-
-    data = post_serper("scrape", {"url": url, "includeMarkdown": True}, api_key, max_retries=3)
-    if data is None:
-        return f"Error scraping {url}"
-    return data.get("markdown") or data.get("text") or "No content extracted."
-
-
 def handle(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-    from qwen_mm_plugins_search.serper import resolve_serper_key
+    from qwen_mm_plugins_search.backends import (
+        backend_error,
+        extract_page,
+        missing_key_error,
+        resolve_api_key,
+        resolve_backend,
+    )
     from shared.content import require_dep, text_error
 
     urls = arguments.get("urls", [])
@@ -46,13 +45,17 @@ def handle(arguments: dict[str, Any]) -> list[dict[str, Any]]:
     if err := require_dep("requests"):
         return err
 
-    api_key = resolve_serper_key(arguments)
+    backend = resolve_backend()
+    if error := backend_error(backend):
+        return text_error(error)
+
+    api_key = resolve_api_key(arguments, backend)
     if not api_key:
-        return text_error("no API key. Set SERPER_API_KEY or pass api_key.")
+        return text_error(missing_key_error(backend))
 
     results = []
     for url in urls:
-        content = _scrape_page(url, api_key)
+        content = extract_page(url, backend, api_key)
         if content and not content.startswith("Error"):
             truncated = content[:CONTENT_LIMIT]
             results.append(f"## {url}\n(Goal: {goal})\n\n{truncated}" if goal else f"## {url}\n\n{truncated}")

--- a/src/capabilities/search/qwen_mm_plugins_search/tools/web_search.py
+++ b/src/capabilities/search/qwen_mm_plugins_search/tools/web_search.py
@@ -1,4 +1,4 @@
-"""MCP tool: text web search via the public Serper (Google Search) API."""
+"""MCP tool: text web search through the configured search backend."""
 
 from __future__ import annotations
 
@@ -6,12 +6,13 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
-SEARCH_PARAMS = {"gl": "us", "hl": "en", "location": "United States", "num": 10}
-
 
 class WebSearchArgs(BaseModel):
     queries: list[str] = Field(description="List of search queries to execute.")
-    api_key: Optional[str] = Field(default=None, description="Serper API key (defaults to SERPER_API_KEY).")
+    api_key: Optional[str] = Field(
+        default=None,
+        description="API key for the selected search backend (defaults to its backend-specific environment key).",
+    )
 
 
 TOOL: dict[str, Any] = {
@@ -24,7 +25,7 @@ TOOL: dict[str, Any] = {
 
 
 def _format_results(docs: list[dict[str, Any]], start_id: int = 1) -> tuple[str, int]:
-    """Render Serper 'organic' docs; returns (text, next_id) with contiguous numbering."""
+    """Render normalized docs; returns (text, next_id) with contiguous numbering."""
     lines = []
     i = start_id
     for doc in docs:
@@ -41,7 +42,13 @@ def _format_results(docs: list[dict[str, Any]], start_id: int = 1) -> tuple[str,
 
 
 def handle(arguments: dict[str, Any]) -> list[dict[str, Any]]:
-    from qwen_mm_plugins_search.serper import post_serper, resolve_serper_key
+    from qwen_mm_plugins_search.backends import (
+        backend_error,
+        missing_key_error,
+        resolve_api_key,
+        resolve_backend,
+        search_text,
+    )
     from shared.content import require_dep, text_error
 
     queries = arguments.get("queries", [])
@@ -50,15 +57,18 @@ def handle(arguments: dict[str, Any]) -> list[dict[str, Any]]:
     if err := require_dep("requests"):
         return err
 
-    api_key = resolve_serper_key(arguments)
+    backend = resolve_backend()
+    if error := backend_error(backend):
+        return text_error(error)
+
+    api_key = resolve_api_key(arguments, backend)
     if not api_key:
-        return text_error("no API key. Set SERPER_API_KEY or pass api_key.")
+        return text_error(missing_key_error(backend))
 
     all_results = []
     idx = 1
     for q in queries:
-        data = post_serper("search", {"q": q, **SEARCH_PARAMS}, api_key, max_retries=10)
-        docs = (data or {}).get("organic", [])
+        docs = search_text(q, backend, api_key)
         text, idx = _format_results(docs, idx)
         all_results.append(f"## Query: {q}\n{text}" if len(queries) > 1 else text)
 

--- a/src/capabilities/search/skill/SKILL.md
+++ b/src/capabilities/search/skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: qwen-mm-plugins-search
-description: Web and reverse-image search MCP tools (Serper) for confirming facts — web_search (find facts), web_extractor (read a page in depth), image_search (reverse-search a frame to identify an entity). Use to verify anything you cannot confirm from the media alone.
+description: Web search and page extraction MCP tools (Serper, Exa, or Tavily) plus Serper Lens reverse-image search for confirming facts — web_search (find facts), web_extractor (read a page in depth), image_search (reverse-search a frame to identify an entity). Use to verify anything you cannot confirm from the media alone.
 ---
 
 # Qwen-MM-Plugins Search
 
-You have `qwen-mm-plugins-search` MCP tools available. They call the Serper API to look things up on the web. Needs `SERPER_API_KEY`.
+You have `qwen-mm-plugins-search` MCP tools available. With `QWEN_MM_SEARCH_BACKEND` unset or set to `auto`, `web_search` and `web_extractor` choose the first configured key in this order: `SERPER_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`. Set the selector to `serper`, `tavily`, or `exa` to pin a backend; explicit selection does not fall back when its key is missing. Independently of that selection, `image_search` always uses Serper Lens and reads `SERPER_API_KEY`.
 
 Check the `qwen-mm-plugins-search` tools in your tool list for full schemas and parameters.
 

--- a/src/mcp_framework.py
+++ b/src/mcp_framework.py
@@ -14,7 +14,7 @@ Depends only on the `mcp` SDK (bundles FastMCP + pydantic) + anyio, so servers s
 
 from __future__ import annotations
 
-__version__ = "1.0.1"  # distribution/release-train version; plugin versions are per capability
+__version__ = "1.0.2"  # distribution/release-train version; plugin versions are per capability
 
 import asyncio
 import importlib

--- a/src/shared/env.py
+++ b/src/shared/env.py
@@ -143,7 +143,22 @@ CONFIG_FIELDS: list[tuple[str, bool, str, str, str]] = [
         "DashScope compat URL",
         "override the DashScope OpenAI-compatible base URL",
     ),
-    ("SERPER_API_KEY", True, "Credentials & endpoints", "", "web_search / web_extractor / image_search"),
+    (
+        "QWEN_MM_SEARCH_BACKEND",
+        False,
+        "Credentials & endpoints",
+        "auto",
+        "text search backend (auto: serper > tavily > exa; or choose one)",
+    ),
+    (
+        "SERPER_API_KEY",
+        True,
+        "Credentials & endpoints",
+        "",
+        "Serper web_search / web_extractor and Serper-only image_search",
+    ),
+    ("EXA_API_KEY", True, "Credentials & endpoints", "", "Exa web_search / web_extractor"),
+    ("TAVILY_API_KEY", True, "Credentials & endpoints", "", "Tavily web_search / web_extractor"),
     ("SAM3_SERVER_URL", False, "Credentials & endpoints", "", "segmentation SAM3 server URL"),
     ("ASR_SERVER_URLS", False, "Credentials & endpoints", "", "self-hosted ASR fallback URLs (comma-separated)"),
     # Directories & limits

--- a/tests/test_api_reachability.py
+++ b/tests/test_api_reachability.py
@@ -6,7 +6,8 @@ They require an explicit opt-in in addition to the relevant key, so a plain
 `pytest tests/` stays offline even on a configured developer machine.
 
 Run them explicitly with real creds:
-    QWEN_MM_RUN_REACHABILITY=1 DASHSCOPE_API_KEY=... SERPER_API_KEY=... \
+    QWEN_MM_RUN_REACHABILITY=1 DASHSCOPE_API_KEY=... \
+        QWEN_MM_SEARCH_BACKEND=exa EXA_API_KEY=... \
         pytest -m reachability tests/
 Skip them even when keys are present:
     pytest -m "not reachability" tests/
@@ -23,22 +24,27 @@ import subprocess
 
 import pytest
 
+from qwen_mm_plugins_search.backends import BACKEND_KEY_ENVS, resolve_backend
 from shared.env import get_env
 
 pytestmark = pytest.mark.reachability
 
 RUN_REACHABILITY = os.environ.get("QWEN_MM_RUN_REACHABILITY") == "1"
 HAS_DASHSCOPE = bool(get_env("DASHSCOPE_API_KEY"))
-HAS_SERPER = bool(get_env("SERPER_API_KEY"))
+SEARCH_BACKEND = resolve_backend()
+SEARCH_KEY_ENV = BACKEND_KEY_ENVS.get(SEARCH_BACKEND)
+HAS_SEARCH_KEY = bool(SEARCH_KEY_ENV and get_env(SEARCH_KEY_ENV))
 HAS_FFMPEG = shutil.which("ffmpeg") is not None and shutil.which("ffprobe") is not None
 
 requires_dashscope = pytest.mark.skipif(
     not RUN_REACHABILITY or not HAS_DASHSCOPE,
     reason="set QWEN_MM_RUN_REACHABILITY=1 and DASHSCOPE_API_KEY to run live checks",
 )
-requires_serper = pytest.mark.skipif(
-    not RUN_REACHABILITY or not HAS_SERPER,
-    reason="set QWEN_MM_RUN_REACHABILITY=1 and SERPER_API_KEY to run live checks",
+requires_search = pytest.mark.skipif(
+    not RUN_REACHABILITY or not HAS_SEARCH_KEY,
+    reason=(
+        "set QWEN_MM_RUN_REACHABILITY=1 and a search API key; optionally set QWEN_MM_SEARCH_BACKEND to pin a provider"
+    ),
 )
 
 
@@ -113,10 +119,10 @@ def test_transcribe_audio_reachable(tmp_path):
     _assert_reached(blocks)
 
 
-# ── Serper (web_search) ──────────────────────────────────────────────
+# ── Selected search backend (web_search) ─────────────────────────────
 
 
-@requires_serper
+@requires_search
 def test_web_search_reachable():
     from qwen_mm_plugins_search.tools import web_search
 

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -4,10 +4,10 @@ Understanding tools live in the qwen-mm-plugins-api capability, grouped by model
 (qwen_mm_plugins_api.vl: vision_chat / ocr / grounding; qwen_mm_plugins_api.others: segmentation /
 asr — the Omni family in qwen_mm_plugins_api.omni is covered by test_api_omni.py); web +
 reverse-image search lives in qwen-mm-plugins-search (qwen_mm_plugins_search.tools +
-its serper client). These tools normally hit an external endpoint (DashScope
-OpenAI-compatible, Serper, a SAM3 server). The handlers all import their network boundary
+its pluggable backends). These tools normally hit an external endpoint (DashScope
+OpenAI-compatible, Serper/Exa/Tavily, a SAM3 server). The handlers all import their network boundary
 lazily *inside* `handle`, so — exactly like test_api_clients.py — monkeypatching the module
-attribute (`call_openai_chat`, `serper.post_serper`, `requests.post`) is enough to exercise
+attribute (`call_openai_chat`, `backends.search_text`, `serper.post_serper`, `requests.post`) is enough to exercise
 the handler with NO live network and NO API key. Nothing here should ever touch the wire.
 
 Split into three layers:
@@ -39,6 +39,7 @@ from qwen_mm_plugins_api.vl import (  # noqa: E402
     ocr,
     vision_chat,
 )
+from qwen_mm_plugins_search import backends as search_backends  # noqa: E402
 from qwen_mm_plugins_search import serper  # noqa: E402
 from qwen_mm_plugins_search.tools import (  # noqa: E402
     image_search,
@@ -55,6 +56,12 @@ def _chat_response(content: str):
     """Mimic the OpenAI SDK response shape the handlers read: resp.choices[0].message.content."""
     message = types.SimpleNamespace(content=content)
     return types.SimpleNamespace(choices=[types.SimpleNamespace(message=message)])
+
+
+@pytest.fixture(autouse=True)
+def _default_search_backend(monkeypatch):
+    """Keep handler tests independent of a developer's persisted backend selection."""
+    monkeypatch.setattr(search_backends, "resolve_backend", lambda: "serper")
 
 
 class _FakeHTTPResponse:
@@ -193,14 +200,20 @@ def test_web_extractor_empty_urls_guard():
 
 
 def test_web_search_missing_key_guard(monkeypatch):
-    monkeypatch.setattr(serper, "resolve_serper_key", lambda a: "")
+    monkeypatch.setattr(search_backends, "resolve_api_key", lambda *_a: "")
     blocks = web_search.handle({"queries": ["hello"]})
     assert _is_error(blocks) and "API key" in blocks[0]["text"]
 
 
 def test_image_search_missing_key_guard(monkeypatch):
+    monkeypatch.setattr(
+        search_backends,
+        "resolve_backend",
+        lambda: pytest.fail("image_search must not consult the text-search backend"),
+    )
     monkeypatch.setattr(serper, "resolve_serper_key", lambda a: "")
-    assert _is_error(image_search.handle({"image_path": "/nope.jpg"}))
+    blocks = image_search.handle({"image_path": "/nope.jpg"})
+    assert _is_error(blocks) and "SERPER_API_KEY" in blocks[0]["text"]
 
 
 def test_segmentation_missing_server_guard(monkeypatch):
@@ -359,7 +372,7 @@ def test_grounding_maps_boxes_and_draws(monkeypatch, sample_image):
 
 
 def test_web_search_formats_serper_docs(monkeypatch):
-    monkeypatch.setattr(serper, "resolve_serper_key", lambda a: "k")
+    monkeypatch.setattr(search_backends, "resolve_api_key", lambda *_a: "k")
     monkeypatch.setattr(
         serper,
         "post_serper",
@@ -371,7 +384,7 @@ def test_web_search_formats_serper_docs(monkeypatch):
 
 
 def test_web_search_multi_query_headers_and_numbering(monkeypatch):
-    monkeypatch.setattr(serper, "resolve_serper_key", lambda a: "k")
+    monkeypatch.setattr(search_backends, "resolve_api_key", lambda *_a: "k")
     seq = iter(
         [
             {"organic": [{"link": "http://a", "title": "A"}]},
@@ -385,13 +398,34 @@ def test_web_search_multi_query_headers_and_numbering(monkeypatch):
 
 
 def test_web_extractor_truncates_and_labels_goal(monkeypatch):
-    monkeypatch.setattr(serper, "resolve_serper_key", lambda a: "k")
+    monkeypatch.setattr(search_backends, "resolve_api_key", lambda *_a: "k")
     monkeypatch.setattr(serper, "post_serper", lambda *a, **k: {"markdown": "M" * 20_000})
     blocks = web_extractor.handle({"urls": ["http://p"], "goal": "find X"})
     text = blocks[0]["text"]
     assert "## http://p" in text and "Goal: find X" in text
     body = text.split("\n\n", 2)[-1]
     assert len(body) <= web_extractor.CONTENT_LIMIT
+
+
+def test_image_search_ignores_text_backend_and_uses_serper(monkeypatch):
+    monkeypatch.setattr(
+        search_backends,
+        "resolve_backend",
+        lambda: pytest.fail("image_search must not consult the text-search backend"),
+    )
+    monkeypatch.setattr(serper, "resolve_serper_key", lambda _a: "serper-key")
+    monkeypatch.setattr(
+        serper,
+        "post_serper",
+        lambda *_a, **_k: {
+            "organic": [{"title": "match", "link": "https://example.com/match", "imageUrl": "https://img"}]
+        },
+    )
+
+    blocks = image_search.handle({"image_path": "https://example.com/source.jpg"})
+
+    assert not _is_error(blocks)
+    assert "https://example.com/match" in blocks[0]["text"]
 
 
 def test_image_search_url_fast_path(monkeypatch):

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -29,6 +29,16 @@ def test_run_cmd_propagates_command_failure():
     assert result.returncode == 0, result.stderr
 
 
+def test_config_spec_lists_search_backend_selector_and_keys():
+    result = _bash('printf "%s\\n" "${CONFIG_SPEC[@]}"')
+    assert result.returncode == 0, result.stderr
+    rows = result.stdout.splitlines()
+    assert any(row.startswith("QWEN_MM_SEARCH_BACKEND|0|cred|auto|") for row in rows)
+    assert any(row.startswith("SERPER_API_KEY|1|cred||") for row in rows)
+    assert any(row.startswith("EXA_API_KEY|1|cred||") for row in rows)
+    assert any(row.startswith("TAVILY_API_KEY|1|cred||") for row in rows)
+
+
 def test_cap_spec_uses_file_url_for_local_checkout(tmp_path):
     checkout = tmp_path / "checkout with spaces"
     checkout.mkdir()
@@ -313,7 +323,7 @@ test "$?" -eq 1
 def test_cap_spec_defaults_to_capability_stable_tag():
     result = _bash("REPO_REF=; cap_spec search")
     assert result.returncode == 0, result.stderr
-    assert result.stdout.endswith("@qwen-mm-plugins-search-v1.0.1")
+    assert result.stdout.endswith("@qwen-mm-plugins-search-v1.0.2")
 
 
 def test_explicit_ref_overrides_package_and_marketplace():
@@ -329,7 +339,7 @@ def test_explicit_ref_overrides_package_and_marketplace():
 def test_gemini_skill_checkout_uses_same_stable_tag():
     result = _bash("QMP_DRY=1; REPO_REF=; install_gemini_skill gemini search")
     assert result.returncode == 0, result.stderr
-    assert "fetch --depth 1 origin qwen-mm-plugins-search-v1.0.1" in result.stdout
+    assert "fetch --depth 1 origin qwen-mm-plugins-search-v1.0.2" in result.stdout
     assert "--path src/capabilities/search/skill" in result.stdout
 
 
@@ -353,7 +363,7 @@ def test_post_update_hint_explains_how_to_activate_updated_components(harness, e
 def test_manual_update_prints_same_tag_for_skill_and_mcp_without_claiming_detection():
     result = _bash("show_manual update qwen-mm-plugins-search")
     assert result.returncode == 0, result.stderr
-    tag = "qwen-mm-plugins-search-v1.0.1"
+    tag = "qwen-mm-plugins-search-v1.0.2"
     repo = "https://github.com/QwenLM/Qwen-MM-Plugins.git"
     assert f"/tree/{tag}/src/capabilities/search/skill" in result.stdout
     assert f"qwen-mm-plugins[search] @ git+{repo}@{tag}" in result.stdout

--- a/tests/test_search_backends.py
+++ b/tests/test_search_backends.py
@@ -1,0 +1,223 @@
+"""Offline contract tests for the Serper / Exa / Tavily search adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp")
+
+import shared.env as shared_env  # noqa: E402
+from qwen_mm_plugins_search import backends, serper  # noqa: E402
+
+
+def _fake_env(values):
+    return lambda name, default=None: values.get(name, default)
+
+
+def test_explicit_backend_is_normalized_and_does_not_fallback(monkeypatch):
+    monkeypatch.setattr(
+        shared_env,
+        "get_env",
+        _fake_env({"QWEN_MM_SEARCH_BACKEND": "  TAVILY  ", "SERPER_API_KEY": "serper-key"}),
+    )
+    assert backends.resolve_backend() == "tavily"
+
+    monkeypatch.setattr(
+        shared_env,
+        "get_env",
+        _fake_env({"QWEN_MM_SEARCH_BACKEND": "serper", "TAVILY_API_KEY": "tavily-key"}),
+    )
+    assert backends.resolve_backend() == "serper"
+
+
+@pytest.mark.parametrize(
+    "values,expected",
+    [
+        (
+            {"SERPER_API_KEY": "s", "TAVILY_API_KEY": "t", "EXA_API_KEY": "e"},
+            "serper",
+        ),
+        ({"TAVILY_API_KEY": "t", "EXA_API_KEY": "e"}, "tavily"),
+        ({"EXA_API_KEY": "e"}, "exa"),
+        ({}, "serper"),
+    ],
+)
+def test_automatic_backend_priority(monkeypatch, values, expected):
+    monkeypatch.setattr(shared_env, "get_env", _fake_env(values))
+    assert backends.resolve_backend() == expected
+
+
+@pytest.mark.parametrize("selector", ["", "   ", "auto", " AUTO "])
+def test_blank_or_auto_selector_uses_configured_keys(monkeypatch, selector):
+    monkeypatch.setattr(
+        shared_env,
+        "get_env",
+        _fake_env({"QWEN_MM_SEARCH_BACKEND": selector, "TAVILY_API_KEY": "tavily-key"}),
+    )
+    assert backends.resolve_backend() == "tavily"
+
+
+@pytest.mark.parametrize(
+    "backend,env_name",
+    [("serper", "SERPER_API_KEY"), ("exa", "EXA_API_KEY"), ("tavily", "TAVILY_API_KEY")],
+)
+def test_backend_specific_key_resolution_and_explicit_override(monkeypatch, backend, env_name):
+    seen = []
+
+    def fake_get_env(name, default=None):
+        seen.append(name)
+        return "env-key"
+
+    monkeypatch.setattr(shared_env, "get_env", fake_get_env)
+    assert backends.resolve_api_key({}, backend) == "env-key"
+    assert seen == [env_name]
+
+    seen.clear()
+    assert backends.resolve_api_key({"api_key": "explicit"}, backend) == "explicit"
+    assert seen == []
+
+
+def test_invalid_backend_message_lists_choices():
+    error = backends.backend_error("other")
+    assert error and "serper, exa, tavily" in error
+    assert backends.backend_error("exa") is None
+
+
+def test_shared_config_catalog_lists_backend_selector_and_keys():
+    fields = {key: (secret, default) for key, secret, _group, default, _description in shared_env.CONFIG_FIELDS}
+    assert fields["QWEN_MM_SEARCH_BACKEND"] == (False, "auto")
+    assert fields["SERPER_API_KEY"] == (True, "")
+    assert fields["EXA_API_KEY"] == (True, "")
+    assert fields["TAVILY_API_KEY"] == (True, "")
+
+
+def test_serper_search_adapter_normalizes_results(monkeypatch):
+    calls = []
+
+    def fake_post(path, payload, api_key, **kwargs):
+        calls.append((path, payload, api_key, kwargs))
+        return {"organic": [{"link": "https://s", "title": "S", "snippet": "body", "date": "today"}]}
+
+    monkeypatch.setattr(serper, "post_serper", fake_post)
+    docs = backends.search_text("q", "serper", "key")
+
+    assert docs == [{"link": "https://s", "title": "S", "snippet": "body", "date": "today"}]
+    assert calls[0][0] == "search"
+    assert calls[0][1]["q"] == "q" and calls[0][1]["num"] == 10
+
+
+@pytest.mark.parametrize(
+    "backend,response,expected,url_suffix,expected_header,payload_checks",
+    [
+        (
+            "exa",
+            {"results": [{"url": "https://e", "title": "E", "text": "exa body", "publishedDate": "2026"}]},
+            {"link": "https://e", "title": "E", "snippet": "exa body", "date": "2026"},
+            "/search",
+            ("x-api-key", "key"),
+            {
+                "query": "q",
+                "numResults": 10,
+                "contents": {"text": {"maxCharacters": backends.SEARCH_SNIPPET_LIMIT}},
+            },
+        ),
+        (
+            "tavily",
+            {"results": [{"url": "https://t", "title": "T", "content": "tavily body"}]},
+            {"link": "https://t", "title": "T", "snippet": "tavily body", "date": "N/A"},
+            "/search",
+            ("Authorization", "Bearer key"),
+            {"query": "q", "search_depth": "basic", "max_results": 10, "include_answer": False},
+        ),
+    ],
+)
+def test_non_serper_search_adapters(
+    monkeypatch,
+    backend,
+    response,
+    expected,
+    url_suffix,
+    expected_header,
+    payload_checks,
+):
+    calls: list[tuple[str, dict[str, Any], dict[str, str], dict[str, Any]]] = []
+
+    def fake_post(url, payload, headers, **kwargs):
+        calls.append((url, payload, headers, kwargs))
+        return response
+
+    monkeypatch.setattr(backends, "_post_json", fake_post)
+    docs = backends.search_text("q", backend, "key")
+
+    assert docs == [expected]
+    url, payload, headers, kwargs = calls[0]
+    assert url.endswith(url_suffix)
+    assert headers[expected_header[0]] == expected_header[1]
+    assert payload == payload_checks
+    assert kwargs["max_retries"] == 10
+
+
+@pytest.mark.parametrize(
+    "backend,response,expected,url_suffix,expected_header,expected_payload",
+    [
+        (
+            "exa",
+            {"results": [{"url": "https://e", "text": "exa page"}]},
+            "exa page",
+            "/contents",
+            ("x-api-key", "key"),
+            {"urls": ["https://page"], "text": {"maxCharacters": backends.EXTRACT_CONTENT_LIMIT}},
+        ),
+        (
+            "tavily",
+            {"results": [{"url": "https://page", "raw_content": "tavily page"}]},
+            "tavily page",
+            "/extract",
+            ("Authorization", "Bearer key"),
+            {"urls": ["https://page"], "format": "markdown"},
+        ),
+    ],
+)
+def test_non_serper_extraction_adapters(
+    monkeypatch,
+    backend,
+    response,
+    expected,
+    url_suffix,
+    expected_header,
+    expected_payload,
+):
+    calls = []
+
+    def fake_post(url, payload, headers, **kwargs):
+        calls.append((url, payload, headers, kwargs))
+        return response
+
+    monkeypatch.setattr(backends, "_post_json", fake_post)
+    assert backends.extract_page("https://page", backend, "key") == expected
+
+    url, payload, headers, kwargs = calls[0]
+    assert url.endswith(url_suffix)
+    assert headers[expected_header[0]] == expected_header[1]
+    assert payload == expected_payload
+    assert kwargs["max_retries"] == 3
+
+
+@pytest.mark.parametrize("backend", ["exa", "tavily"])
+def test_extraction_empty_result_is_reported(monkeypatch, backend):
+    monkeypatch.setattr(backends, "_post_json", lambda *_a, **_k: {"results": []})
+    assert backends.extract_page("https://page", backend, "key") == "Error scraping https://page"
+
+
+def test_exa_extraction_checks_per_url_status(monkeypatch):
+    monkeypatch.setattr(
+        backends,
+        "_post_json",
+        lambda *_a, **_k: {
+            "results": [{"text": "stale"}],
+            "statuses": [{"id": "https://page", "status": "error"}],
+        },
+    )
+    assert backends.extract_page("https://page", "exa", "key") == "Error scraping https://page"


### PR DESCRIPTION
## Summary

- Add Serper, Tavily, and Exa support for text search and extraction.
- Auto-select configured backends in Serper → Tavily → Exa order.
- Keep explicit backend selection strict.
- Keep reverse-image search Serper-only.
- Bump the Search plugin to v1.0.2.

## Testing

- Offline test suite passed.
- Tavily search and extraction verified with the real API.