### PR TITLE
fix(shared): report display dimensions for rotation-tagged videos

### DIFF
--- a/src/shared/video.py
+++ b/src/shared/video.py
@@ -99,6 +99,11 @@ def video_duration_exceeds(path: str, max_seconds: float | None) -> bool:
 
 
 def get_video_info(video_path: str) -> dict:
+    """Probe a video for the numbers frame extraction needs: display ``width``/``height``, duration,
+    native fps, and the ``rotation`` flag. Dimensions are the *display* orientation (stored pair
+    swapped on a quarter turn) — ffmpeg autorotates on decode, so that is what a ``-vf`` filter and
+    the extracted frames actually see. Use ``probe_media`` / ``media_info`` for the stored geometry.
+    """
     result = subprocess.run(
         [
             find_tool("ffprobe"),
@@ -156,6 +161,12 @@ def get_video_info(video_path: str) -> dict:
                 rotation = int(float(rotate_tag))
             except (TypeError, ValueError):
                 rotation = 0
+
+    # ffmpeg autorotates on decode (default since 2.7), so a quarter-turn clip is already upright when
+    # a caller's `-vf scale=w:h` runs. Report the display pair: scaling an upright frame to the stored
+    # (sideways) target is what distorts portrait phone video into a stretched landscape frame.
+    if abs(rotation) % 180 == 90:
+        width, height = height, width
 
     return {
         "width": width,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,6 +120,39 @@ def sample_video(tmp_path_factory) -> str:
 
 
 @pytest.fixture(scope="session")
+def rotated_video(tmp_path_factory) -> str:
+    """A 2s, 320×120 clip with a centered 100×100 white square, tagged rotation 90 — the shape a
+    portrait phone video has on disk: sideways stored pixels plus a display-matrix flag."""
+    if not HAS_FFMPEG:
+        pytest.skip("ffmpeg not available")
+    media = tmp_path_factory.mktemp("media")
+    plain, path = media / "plain.mp4", media / "rotated.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:size=320x120:rate=10:duration=2,drawbox=x=110:y=10:w=100:h=100:color=white:t=fill",
+            "-pix_fmt",
+            "yuv420p",
+            str(plain),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    # -display_rotation needs ffmpeg >= 6.0; skip rather than fail on an older build.
+    tagged = subprocess.run(
+        ["ffmpeg", "-y", "-display_rotation", "90", "-i", str(plain), "-c", "copy", str(path)],
+        capture_output=True,
+    )
+    if tagged.returncode != 0:
+        pytest.skip("ffmpeg cannot tag display rotation (needs -display_rotation, ffmpeg >= 6.0)")
+    return str(path)
+
+
+@pytest.fixture(scope="session")
 def sample_media_av(tmp_path_factory) -> str:
     """A 3s MP4 with both tracks: video (testsrc 160×120 @ 10fps) + audio (440 Hz sine, AAC)."""
     if not HAS_FFMPEG:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -129,6 +129,30 @@ def test_get_video_info_reports_rotation(sample_video):
     assert info["native_fps"] > 0
 
 
+def test_get_video_info_swaps_rotated_dimensions(rotated_video):
+    from shared.video import get_video_info
+
+    info = get_video_info(rotated_video)
+    # Stored 320×120 + rotation 90. ffmpeg autorotates on decode, so the pair callers scale to has to
+    # be the display orientation; scaling the upright frame to the stored one distorts it.
+    assert info["rotation"] in (90, -90)
+    assert (info["width"], info["height"]) == (120, 320)
+
+
+def test_read_video_preserves_rotated_aspect(rotated_video):
+    # A square in a rotation-tagged source must stay square in the extracted frames (regression
+    # against a scale target taken from the stored, pre-rotation dimensions).
+    content = video_reader.handle({"video_path": rotated_video, "budget": "small", "max_frames": 2})
+    assert not _is_error(content)
+    frame = _decode_image(_blocks_by_type(content, "image")[0])
+    assert frame.size[1] > frame.size[0], f"portrait source produced a {frame.size} landscape frame"
+    box = frame.convert("L").point(lambda p: 255 if p > 128 else 0).getbbox()
+    assert box, "white square not found in the extracted frame"
+    w, h = box[2] - box[0], box[3] - box[1]
+    # Only patch-grid rounding may move the aspect ratio; the pre-fix stretch was ~3x.
+    assert 0.8 < w / h < 1.25, f"square rendered as {w}x{h} (aspect {w / h:.2f})"
+
+
 def test_read_video_respects_max_frames(sample_video):
     # 6s @ ~2fps auto → ~12 frames; cap to 3 (above the 2-frame floor) must hold.
     content = video_reader.handle({"video_path": sample_video, "budget": "small", "max_frames": 3})


### PR DESCRIPTION
Fixes #20

## What

`get_video_info` (`src/shared/video.py`) now returns the **display** width/height for videos carrying quarter-turn rotation metadata (`abs(rotation) % 180 == 90`), i.e. the stored pair swapped. The `rotation` field is unchanged and still reported.

## Why

ffmpeg autorotates on decode (default since 2.7), so by the time a caller's `-vf scale=w:h` filter runs, a portrait phone video is already upright — but the scale target was computed from ffprobe's stored (pre-rotation, landscape) dimensions. `scale=w:h` does not preserve aspect ratio, so every extracted frame of a rotation-tagged video was anisotropically stretched (~3x for 9:16 material), while the summary even printed `rotation 90°` correctly. The repo's own core SKILL.md states the expected behavior: "the display orientation differs from stored pixels; bake it in".

Swapping once at the source fixes all four affected call sites with one change: `read_video` (core), `encode_video_source` (`shared/api_openai.py`), and the omni `_encode_video` / `_fit_frames` paths. `save_view` and `media_info` don't consume these fields (native extraction / `probe_media`), so their behavior is unchanged. For non-rotated videos nothing changes.

## Regression test

`tests/test_tools.py` adds two tests against a new `rotated_video` fixture (stored 320×120 with a centered 100×100 white square, tagged `rotation 90` — the on-disk shape of a portrait phone clip):

- `test_get_video_info_swaps_rotated_dimensions` — the reported pair is the display orientation (120, 320)
- `test_read_video_preserves_rotated_aspect` — extracted frames are portrait and the square stays square (pre-fix it rendered ~3:1)

Both fail on `main` and pass with the fix:

```
# on main (fix stashed):
tests/test_tools.py::test_get_video_info_swaps_rotated_dimensions FAILED
    assert (320, 120) == (120, 320)
tests/test_tools.py::test_read_video_preserves_rotated_aspect FAILED
    AssertionError: portrait source produced a (480, 160) landscape frame

# with the fix:
322 passed, 21 skipped, 6 deselected in 15.65s
```

## Verification

```
$ uv run --no-project --python 3.12 --with pytest --with "mcp>=1,<2" --with "anyio>=4,<5" \
    --with "pydantic>=2" --with "pillow<12" --with "numpy<3" --with requests --with openai \
    python -m pytest -q -m "not reachability"
322 passed, 21 skipped, 6 deselected in 15.65s

$ python3 scripts/check_manifests.py
OK — 9 capabilities consistent across marketplace.json, plugin manifests and pyproject.toml

$ ruff check src/shared/video.py tests/conftest.py tests/test_tools.py
All checks passed!
```

Not run: the opt-in `reachability` tests (live provider credentials; they are also deselected in CI). Note the new fixture skips cleanly on ffmpeg < 6.0 (no `-display_rotation`) rather than failing.

---

This fix was developed with AI assistance; the author has reviewed and locally verified every change.
