### PR TITLE
test(core): skip LaTeX renderer cases when pypdfium2 is missing

### DIFF
--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -55,8 +55,8 @@ TESTS = [
     ("sample.geojson", "image", 1, "GeoJSON (geopandas)", ["geopandas"]),
     ("sample.ipynb", "text", 3, "Jupyter notebook", ["nbformat"]),
     ("charts.ipynb", "image", 3, "Jupyter notebook (charts)", ["nbformat"]),
-    ("sample.tex", "image", 1, "LaTeX (pdflatex)", ["pdflatex"]),
-    ("tex_project/main.tex", "image", 1, "LaTeX multi-file", ["pdflatex"]),
+    ("sample.tex", "image", 1, "LaTeX (pdflatex)", ["pdflatex", "pypdfium2"]),
+    ("tex_project/main.tex", "image", 1, "LaTeX multi-file", ["pdflatex", "pypdfium2"]),
     ("broken.tex", "text", 1, "LaTeX fallback (text)", []),
 ]
 


### PR DESCRIPTION
## What changed

`tests/test_renderers.py` declared only `pdflatex` for the two LaTeX cases. The render path is `.tex → pdflatex → PDF → bitmap`, and the last step needs `pypdfium2` (the `viz` extra). On a machine with TeXLive but without `viz`, the tests fail instead of skipping:

```
AssertionError: Error rendering .tex file: Missing dependency — install with: pip install "qwen-mm-plugins[viz]"
```

The same table already lists both system and Python deps for DOCX/PPTX (`["libreoffice", "pypdfium2"]`). `_has_dep("pypdfium2")` already exists. `tests/test_visualize_real.py` already requires both `pdflatex` and `pypdfium2` for its LaTeX case.

This change adds `"pypdfium2"` to the two LaTeX `requires` lists. No production code change.

## Verification

Isolated venv with `mcp` / `anyio` / `pillow` / `pytest` only, `pdflatex` on PATH, `pypdfium2` absent:

```bash
python -m pytest -q "tests/test_renderers.py::test_renderer[LaTeX (pdflatex)]" \
  "tests/test_renderers.py::test_renderer[LaTeX multi-file]"
```

- Before: 1 failed (`Missing dependency — install with: pip install "qwen-mm-plugins[viz]"`)
- After: 2 skipped

Also ran:

```bash
python -m pytest -m "not reachability" tests/ -k "not STEP and not GLB and not html"
python scripts/check_manifests.py
```

`check_manifests.py` passed. Offline pytest: 280 passed / 6 skipped on this change. Remaining failures were pre-existing Windows environment issues (WSL bash CRLF for `test_install_sh.py`, locale encoding in `test_repo_sync.py`). Native Windows is documented as WSL2-only.

Not tested: real TeXLive `pdflatex` (used a PATH stub so the skip guard is what is under test); GUI / GPU / DashScope reachability; whole-tree `ruff` (pre-existing findings in `edu-agent` / `video-edit` skill scripts; this change is two list literals).

## Compatibility

- [x] Existing MCP tool names, inputs, and outputs are unchanged, or the change is explained above.
- [x] Tests and documentation were updated where behavior changed.
- [x] No credentials, private media, generated artifacts, or machine-specific configuration are included.
