### PR TITLE
test: read plugin manifests as UTF-8

### DIFF
--- a/scripts/rewrite_plugin_sources.py
+++ b/scripts/rewrite_plugin_sources.py
@@ -15,7 +15,7 @@ def _write_if_changed(path: Path, data: dict, original: str) -> bool:
     rendered = json.dumps(data, ensure_ascii=False, indent=2) + "\n"
     if rendered == original:
         return False
-    path.write_text(rendered)
+    path.write_text(rendered, encoding="utf-8")
     return True
 
 
@@ -26,7 +26,7 @@ def _rewrite_marketplace(
     restore: bool,
     versions: dict[str, str],
 ) -> bool:
-    original = path.read_text()
+    original = path.read_text(encoding="utf-8")
     data = json.loads(original)
     found: set[str] = set()
     for plugin in data.get("plugins", []):
@@ -53,7 +53,7 @@ def _rewrite_marketplace(
 
 
 def _rewrite_mcp(path: Path, cap: str, source: str, *, refresh: bool) -> bool:
-    original = path.read_text()
+    original = path.read_text(encoding="utf-8")
     pattern = re.compile(rf"(qwen-mm-plugins\[{re.escape(cap)}\] @ )[^\"\r\n]+")
     rendered, count = pattern.subn(rf"\g<1>{source}", original)
     if count == 0:
@@ -74,7 +74,7 @@ def _rewrite_mcp(path: Path, cap: str, source: str, *, refresh: bool) -> bool:
 
     if rendered == original:
         return False
-    path.write_text(rendered)
+    path.write_text(rendered, encoding="utf-8")
     return True
 
 
@@ -91,7 +91,7 @@ def main() -> int:
     if not (repo / "pyproject.toml").is_file():
         parser.error(f"--repo must be the repository root containing pyproject.toml: {repo}")
 
-    version_data = json.loads((repo / "plugin-versions.json").read_text())
+    version_data = json.loads((repo / "plugin-versions.json").read_text(encoding="utf-8"))
     versions: dict[str, str] = version_data["plugins"]
     capabilities = set(versions) if args.capabilities == ["all"] else set(args.capabilities)
     unknown = capabilities - set(versions)

--- a/tests/test_repo_sync.py
+++ b/tests/test_repo_sync.py
@@ -46,7 +46,7 @@ def _capabilities() -> list[str]:
 
 
 def _load(cap: str, rel: str) -> dict:
-    return json.loads((_CAPS_DIR / cap / rel).read_text())
+    return json.loads((_CAPS_DIR / cap / rel).read_text(encoding="utf-8"))
 
 
 def _server_capabilities() -> list[str]:
@@ -122,7 +122,7 @@ def test_mcp_launch_spec_agrees(cap):
 def test_marketplace_lists_every_capability():
     import mcp_framework
 
-    market = json.loads((_ROOT / ".claude-plugin" / "marketplace.json").read_text())
+    market = json.loads((_ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
     listed = {p["name"] for p in market["plugins"]}
     # `example` is a copy-me template that ships in the repo but is intentionally NOT published to
     # the marketplace (end users shouldn't see a demo plugin). Every other capability must be listed.


### PR DESCRIPTION
## What changed

`tests/test_repo_sync.py` and `scripts/rewrite_plugin_sources.py` called `Path.read_text()` / `write_text()` without an encoding. On Chinese Windows the locale is GBK, so UTF-8 plugin descriptions that contain `—` raise:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94
```

`scripts/check_manifests.py` already reads these files as UTF-8. This change uses `encoding="utf-8"` in the same places.

## Verification

```bash
python -m pytest -q tests/test_repo_sync.py
```

29 passed (these cases previously failed on this Windows checkout with GBK).

Not tested: `bash install.sh local` rewrite path end-to-end; GUI / GPU / reachability.

## Compatibility

- [x] Existing MCP tool names, inputs, and outputs are unchanged, or the change is explained above.
- [x] Tests and documentation were updated where behavior changed.
- [x] No credentials, private media, generated artifacts, or machine-specific configuration are included.
