### PR TITLE
fix(core): declare viz/pypdfium2 for LaTeX SYSTEM_DEPS

### DIFF
--- a/src/capabilities/core/qwen_mm_plugins_core/__init__.py
+++ b/src/capabilities/core/qwen_mm_plugins_core/__init__.py
@@ -44,10 +44,11 @@ SYSTEM_DEPS = [
     },
     {
         "label": "visualize: LaTeX (.tex)",
-        "extra": "system",  # no pip side — pdflatex is system-only (texlive)
+        "extra": "viz",
+        "probe": "pypdfium2",
         "tools": ["pdflatex"],
-        "hint": "apt install texlive-latex-base texlive-latex-extra",
-        "startup": False,  # system-only — report-only, don't nag every startup
+        "hint": "apt install texlive-latex-base texlive-latex-extra   |   brew install --cask basictex",
+        "startup": False,  # TeXLive is heavy — report-only, don't nag every startup
     },
     {
         "label": "visualize: HTML screenshot (Playwright browser)",

--- a/src/shared/syscmd.py
+++ b/src/shared/syscmd.py
@@ -18,7 +18,7 @@ _TOOL_INSTALL_HINT = {
     "ffmpeg": "apt install ffmpeg   |   brew install ffmpeg",
     "ffprobe": "apt install ffmpeg   |   brew install ffmpeg",
     "libreoffice": "apt install libreoffice   |   brew install --cask libreoffice",
-    "pdflatex": "apt install texlive-latex-base texlive-latex-extra",
+    "pdflatex": "apt install texlive-latex-base texlive-latex-extra   |   brew install --cask basictex",
     "blender": "apt install blender   |   brew install --cask blender",
 }
 


### PR DESCRIPTION
## What changed

LaTeX visualize is `.tex → pdflatex → PDF → pypdfium2`, the same PDF-then-raster path as Office. The `--check-system` entry used `extra: "system"` with no `probe`, so a core install without the `viz` extra still reported LaTeX as a system-only row and never mentioned `pypdfium2`. `pyproject.toml` already comments that `viz` covers LaTeX via pypdfium2. Office already uses `extra="viz"` / `probe="pypdfium2"`.

This aligns the LaTeX `SYSTEM_DEPS` row with that pattern and adds the missing macOS brew hint (`brew install --cask basictex`) next to the existing apt line in both `SYSTEM_DEPS` and `shared.syscmd`.

No version bump: check-system copy and install hint only; MCP tool names/inputs/outputs are unchanged.

## Verification

```bash
python -c "from qwen_mm_plugins_core import SYSTEM_DEPS; print([d for d in SYSTEM_DEPS if 'LaTeX' in d['label']][0])"
python scripts/check_manifests.py
python -m pytest -q tests/test_mcp_framework.py
```

LaTeX entry is now `extra=viz`, `probe=pypdfium2`. `check_manifests.py` OK. `tests/test_mcp_framework.py` passed.

Not tested: real TeXLive / BasicTeX install; `--check-system` on a viz-less venv; GUI / GPU / reachability.

## Compatibility

- [x] Existing MCP tool names, inputs, and outputs are unchanged, or the change is explained above.
- [x] Tests and documentation were updated where behavior changed.
- [x] No credentials, private media, generated artifacts, or machine-specific configuration are included.
