### PR TITLE
feat: add DeepSeek Harness support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Qwen multimodal understanding plugins — Agent Skills + MCP servers",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "source": "git-subdir",
         "url": "https://github.com/QwenLM/Qwen-MM-Plugins.git",
         "path": "src/capabilities/core",
-        "ref": "qwen-mm-plugins-core-v1.0.1"
+        "ref": "qwen-mm-plugins-core-v1.0.2"
       },
       "description": "Read and visualize any file (images, video, docs, 3D, and more), plus image tools — crop, annotate, extract frames — as MCP tools."
     },
@@ -25,7 +25,7 @@
         "source": "git-subdir",
         "url": "https://github.com/QwenLM/Qwen-MM-Plugins.git",
         "path": "src/capabilities/api",
-        "ref": "qwen-mm-plugins-api-v1.0.2"
+        "ref": "qwen-mm-plugins-api-v1.0.3"
       },
       "description": "Cloud APIs for understanding media, by model family: VL (vision chat, OCR, grounding), Omni A/V (timestamped captioning, ASR / multi-speaker diarization, temporal grounding, event counting), plus ASR and segmentation (SAM3) — as MCP tools; currently supports DashScope."
     },
@@ -35,7 +35,7 @@
         "source": "git-subdir",
         "url": "https://github.com/QwenLM/Qwen-MM-Plugins.git",
         "path": "src/capabilities/search",
-        "ref": "qwen-mm-plugins-search-v1.0.2"
+        "ref": "qwen-mm-plugins-search-v1.0.3"
       },
       "description": "Web search and page extraction via Serper, Exa, or Tavily, plus Serper Lens reverse-image search as MCP tools."
     },

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -19,6 +19,12 @@ The installer supports Claude Code, Codex, Qoder, OpenClaw, Qwen Code, and Gemin
 each harness's native install mechanism and stores shared configuration in
 `~/.qwen-mm-plugins/config`.
 
+DeepSeek Harness is intentionally not in the harness picker. Its `dsh plugin` command manages the
+profile's JavaScript packages, but it does not register an MCP server or install a Skill. Use the
+[manual DeepSeek Harness setup](manual_harnesses.md#deepseek-harness-developer-preview) instead.
+The installer's **Configure** and **Verify** actions remain usable because they do not depend on a
+harness-specific registration command.
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash
 ```
@@ -78,8 +84,8 @@ See [Local development](local_development.md) for direct source execution and ta
 
 ## Manual Skill + MCP installation
 
-Use this path for opencode, pi, QwenPaw, or another harness without a compatible marketplace. For
-an MCP capability, keep these three values aligned:
+Use this path for DeepSeek Harness, opencode, pi, QwenPaw, or another harness without a compatible
+marketplace. For an MCP capability, keep these three values aligned:
 
 - Skill: `src/capabilities/<cap>/skill`
 - package extra: `qwen-mm-plugins[<cap>]`

--- a/docs/en/manual_harnesses.md
+++ b/docs/en/manual_harnesses.md
@@ -49,6 +49,66 @@ Copy the Skill to `~/.config/opencode/skills/qwen-mm-plugins-<cap>` and add:
 
 Use `~/.config/opencode/opencode.json` or a project-level `opencode.json`.
 
+## DeepSeek Harness (developer preview)
+
+Validated with `@deepseek-ai/dsh` 0.1.0-rc.6. DSH loads Skills from `$DSH_HOME/skills` (normally
+`~/.dsh/skills`) and connects stdio MCP servers through its bundled `@deepseek-ai/dsh-mcp-client`;
+it currently requires manual registration.
+
+Install and start DSH once to create the `web` profile:
+
+```bash
+npm install --global @deepseek-ai/dsh@0.1.0-rc.6
+dsh --profile web
+```
+
+DSH filters credential-like variables from MCP child environments, so write provider settings to
+the shared config file first:
+
+```bash
+bash install.sh configure
+```
+
+Copy the Skill from the tag used by the MCP command:
+
+```bash
+dsh_home=${DSH_HOME:-"$HOME/.dsh"}
+mkdir -p "$dsh_home/skills"
+cp -R /path/to/tagged-checkout/src/capabilities/<cap>/skill \
+  "$dsh_home/skills/qwen-mm-plugins-<cap>"
+```
+
+Add the MCP row to `$DSH_HOME/profiles/web/cordis.patch.yml` (normally
+`~/.dsh/profiles/web/cordis.patch.yml`). Replace an initial `[]`, or merge the row into the existing
+array:
+
+```yaml
+- insert:
+    - id: mcp-qwen-mm-plugins-<cap>
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: qwen-mm-plugins-<cap>
+        transport: stdio
+        command: uvx
+        args:
+          - '--from'
+          - 'qwen-mm-plugins[<cap>] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-<cap>-v<version>'
+          - 'qwen-mm-plugins-<cap>'
+        cwd: !!js process.cwd()
+```
+
+Add one child row per capability. Save the file, restart DSH, and open a new session:
+
+```bash
+dsh --profile web
+```
+
+**Compatibility:** DSH 0.1.0-rc.6 preserves MCP text and structured results but replaces image,
+audio, and resource blocks with `content discarded`. Text results from `vision_chat`, OCR, ASR, and
+search remain usable; workflows that depend on media returned by MCP are incomplete. See the
+upstream
+[`dsh-mcp-client` limitation](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/mcp/mcp-client/README.md#known-limitations-and-deferred-work).
+
 ## pi
 
 pi supports Skills directly; MCP tools require the community adapter:

--- a/docs/zh/installation.md
+++ b/docs/zh/installation.md
@@ -18,6 +18,11 @@
 安装器支持 Claude Code、Codex、Qoder、OpenClaw、Qwen Code 和 Gemini CLI。它调用各 harness
 的原生安装机制，并将共享配置保存在 `~/.qwen-mm-plugins/config`。
 
+DeepSeek Harness 不会出现在 harness 选择列表中。它的 `dsh plugin` 命令只管理 profile 的
+JavaScript 包，不能注册 MCP server 或安装 Skill；请改用
+[DeepSeek Harness 手动配置](manual_harnesses.md)。安装器的
+**Configure** 和 **Verify** 不依赖 harness 专属注册命令，因此仍可使用。
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash
 ```
@@ -75,8 +80,8 @@ bash install.sh local --restore
 
 ## 手动安装 Skill + MCP
 
-opencode、pi、QwenPaw 或其他没有兼容 marketplace 的 harness 使用此方式。对于包含 MCP 的能力，
-以下三处名称必须一致：
+DeepSeek Harness、opencode、pi、QwenPaw 或其他没有兼容 marketplace 的 harness 使用此方式。
+对于包含 MCP 的能力，以下三处名称必须一致：
 
 - Skill：`src/capabilities/<cap>/skill`
 - 包 extra：`qwen-mm-plugins[<cap>]`

--- a/docs/zh/manual_harnesses.md
+++ b/docs/zh/manual_harnesses.md
@@ -49,6 +49,63 @@ claude mcp add qwen-mm-plugins-<cap> -- \
 
 配置文件可以是 `~/.config/opencode/opencode.json` 或项目级 `opencode.json`。
 
+## DeepSeek Harness（developer preview）
+
+已使用 `@deepseek-ai/dsh` 0.1.0-rc.6 验证。DSH 从 `$DSH_HOME/skills`（通常为
+`~/.dsh/skills`）加载 Skill，并通过内置 `@deepseek-ai/dsh-mcp-client` 连接 stdio MCP server；
+目前没有自动注册命令，需要手动配置。
+
+安装并首次启动 DSH，让它创建 `web` profile：
+
+```bash
+npm install --global @deepseek-ai/dsh@0.1.0-rc.6
+dsh --profile web
+```
+
+DSH 会过滤传给 MCP 子进程的凭据类环境变量，因此先把服务配置写入共享文件：
+
+```bash
+bash install.sh configure
+```
+
+从 MCP 命令对应的 tag checkout 复制 Skill：
+
+```bash
+dsh_home=${DSH_HOME:-"$HOME/.dsh"}
+mkdir -p "$dsh_home/skills"
+cp -R /path/to/tagged-checkout/src/capabilities/<cap>/skill \
+  "$dsh_home/skills/qwen-mm-plugins-<cap>"
+```
+
+将 MCP 行添加到 `$DSH_HOME/profiles/web/cordis.patch.yml`（通常为
+`~/.dsh/profiles/web/cordis.patch.yml`）。如果文件内容为 `[]`，直接替换；否则合并到已有数组：
+
+```yaml
+- insert:
+    - id: mcp-qwen-mm-plugins-<cap>
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: qwen-mm-plugins-<cap>
+        transport: stdio
+        command: uvx
+        args:
+          - '--from'
+          - 'qwen-mm-plugins[<cap>] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-<cap>-v<version>'
+          - 'qwen-mm-plugins-<cap>'
+        cwd: !!js process.cwd()
+```
+
+每个 capability 添加一个子项。保存后重启 DSH，并新建会话：
+
+```bash
+dsh --profile web
+```
+
+**兼容性：** DSH 0.1.0-rc.6 可传递 MCP 文本和结构化结果，但会把 image、audio 和 resource
+block 替换为 `content discarded`。`vision_chat`、OCR、ASR 和搜索等文本结果可用；依赖 MCP
+返回媒体内容的流程尚不完整。参见上游
+[`dsh-mcp-client` 限制](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/mcp/mcp-client/README.md#known-limitations-and-deferred-work)。
+
 ## pi
 
 pi 原生支持 Skill；MCP 工具需要社区 adapter：

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ LOCAL_REPO_ROOT=''
 CAP_ITEMS=(core api search video-memory video-edit blender freecad edu-agent)
 # Latest stable plugin versions, in exactly the same order as CAP_ITEMS. Keep this release index in
 # sync with plugin-versions.json; scripts/check_manifests.py and tests/test_install_sh.py enforce it.
-CAP_VERSIONS=(1.0.1 1.0.2 1.0.2 1.0.1 1.0.1 1.0.1 1.0.1 1.0.1)
+CAP_VERSIONS=(1.0.2 1.0.3 1.0.3 1.0.1 1.0.1 1.0.1 1.0.1 1.0.1)
 CAP_DESC=("read/visualize any local file — images, video, docs, 3D"
           "cloud media APIs by model family: VL (vision_chat/ocr/grounding), Omni A/V, ASR, segmentation"
           "web search/extraction (Serper, Exa, Tavily) + Serper reverse-image search"
@@ -48,7 +48,8 @@ is_skill_only() { case "$CAP_SKILL_ONLY" in *" $1 "*) return 0 ;; *) return 1 ;;
 #   MARKETPLACE harnesses install a bundled skill+MCP plugin via their own `plugin install` verb.
 #   CONFIG harnesses have no plugin marketplace, so we register the MCP server (+ skill) via each
 #   harness's native verb (see install_for). Harnesses that need a hand-edited config + a checkout-copied
-#   skill (opencode, QwenPaw, pi) stay docs-only (see docs/en/installation.md), not this menu.
+#   skill (DeepSeek Harness, opencode, QwenPaw, pi) stay docs-only (see docs/en/manual_harnesses.md),
+#   not this menu.
 # Menus, status, and detection iterate ALL_HARNESSES; install_for/_detect_mask/do_uninstall case per one.
 MP_HARNESSES="claude codex qoder openclaw"          # native plugin marketplace (skill+MCP bundled)
 CFG_HARNESSES="qwen-code gemini"                    # native-verb (extensions install / mcp add + skills install)
@@ -1467,8 +1468,9 @@ EOF
     ln -s /path/to/Qwen-MM-Plugins/src/capabilities/core/skill \\
       ~/.claude/skills/qwen-mm-plugins-core
 
-  C) Config-file harnesses (opencode · pi · QwenPaw) — register the MCP server + skill in the
-     harness's own config; exact per-harness blocks are in docs/en/installation.md. pi in brief:
+  C) Config-file harnesses (DeepSeek Harness · opencode · pi · QwenPaw) — register the MCP server +
+     skill in the harness's own config; exact blocks are in docs/en/manual_harnesses.md. DSH has no
+     native Skill/MCP install verb and uses its profile Cordis patch. pi in brief:
     cp -r /path/to/Qwen-MM-Plugins/src/capabilities/core/skill ~/.pi/agent/skills/qwen-mm-plugins-core
     pi install npm:pi-mcp-adapter      # pi's MCP goes through this adapter; skill-only caps need just the copy
 

--- a/plugin-versions.json
+++ b/plugin-versions.json
@@ -1,13 +1,13 @@
 {
-  "distribution_version": "1.0.3",
+  "distribution_version": "1.0.4",
   "tag_format": "qwen-mm-plugins-{cap}-v{version}",
   "plugins": {
-    "api": "1.0.2",
+    "api": "1.0.3",
     "blender": "1.0.1",
-    "core": "1.0.1",
+    "core": "1.0.2",
     "edu-agent": "1.0.1",
     "freecad": "1.0.1",
-    "search": "1.0.2",
+    "search": "1.0.3",
     "video-edit": "1.0.1",
     "video-memory": "1.0.1"
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ Issues = "https://github.com/QwenLM/Qwen-MM-Plugins/issues"
 
 [project.optional-dependencies]
 # capability extras — compose via the profiles below
-api = ["openai", "dashscope", "requests"]     # vision_chat / ocr / grounding / segmentation / ASR
-search = ["requests"]                          # search via Serper / Exa / Tavily; reverse-image via Serper
+api = ["openai", "dashscope", "httpx[socks]", "requests[socks]"]  # cloud media APIs + HTTP/SOCKS
+search = ["requests[socks]"]                    # Serper / Exa / Tavily + optional SOCKS proxy transport
 # viz = the full visualize stack — a `core` install then renders every format out of the box.
 viz = [
     "pypdfium2", "resvg-py", "lxml",          # PDF raster+text (pypdfium2) / SVG (resvg) / DrawIO / LaTeX

--- a/src/capabilities/api/.claude-plugin/plugin.json
+++ b/src/capabilities/api/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-mm-plugins-api",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Qwen-MM-Plugins api — cloud APIs for understanding media, by model family: VL (vision chat, OCR, grounding), Omni A/V (timestamped captioning, ASR / multi-speaker diarization, temporal grounding, event counting), plus ASR and segmentation (SAM3), exposed as an MCP server; currently supports DashScope.",
   "skills": [
     "./skill"
@@ -10,7 +10,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "qwen-mm-plugins[api] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-api-v1.0.2",
+        "qwen-mm-plugins[api] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-api-v1.0.3",
         "qwen-mm-plugins-api"
       ]
     }

--- a/src/capabilities/api/.codex-plugin/plugin.json
+++ b/src/capabilities/api/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-mm-plugins-api",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Qwen-MM-Plugins api — cloud APIs for understanding media, by model family: VL (vision chat, OCR, grounding), Omni A/V (timestamped captioning, ASR / multi-speaker diarization, temporal grounding, event counting), plus ASR and segmentation (SAM3), exposed as an MCP server; currently supports DashScope.",
   "skills": "./skill",
   "mcpServers": "./.mcp.json"

--- a/src/capabilities/api/.mcp.json
+++ b/src/capabilities/api/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "qwen-mm-plugins[api] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-api-v1.0.2",
+        "qwen-mm-plugins[api] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-api-v1.0.3",
         "qwen-mm-plugins-api"
       ]
     }

--- a/src/capabilities/api/.qoder-plugin/plugin.json
+++ b/src/capabilities/api/.qoder-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qwen-mm-plugins-api",
   "displayName": "Qwen MM Plugins API",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cloud APIs for understanding media, by model family: VL (vision chat, OCR, grounding), Omni A/V (timestamped captioning, ASR / multi-speaker diarization, temporal grounding, event counting), plus ASR and segmentation (SAM3) as MCP tools; currently supports DashScope.",
   "skills": "./skill",
   "mcp": ".mcp.json"

--- a/src/capabilities/api/qwen_mm_plugins_api/__init__.py
+++ b/src/capabilities/api/qwen_mm_plugins_api/__init__.py
@@ -13,7 +13,7 @@ Local file reading/visualization lives in ``core``; fact-finding/confirmation li
 
 from mcp_framework import build_registry
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 # Auto-discover tools from the three model-family subpackages.
 SPECS, get_handler, list_tools = build_registry(__name__, ["vl", "omni", "others"])

--- a/src/capabilities/core/.claude-plugin/plugin.json
+++ b/src/capabilities/core/.claude-plugin/plugin.json
@@ -1,12 +1,18 @@
 {
   "name": "qwen-mm-plugins-core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Qwen-MM-Plugins — read/visualize any file (images, video, PDF, Office, code, SVG, 3D, GIS, notebooks) plus OCR, grounding, segmentation, ASR and vision-chat, exposed as an MCP server.",
-  "skills": ["./skill"],
+  "skills": [
+    "./skill"
+  ],
   "mcpServers": {
     "qwen-mm-plugins-core": {
       "command": "uvx",
-      "args": ["--from", "qwen-mm-plugins[core] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-core-v1.0.1", "qwen-mm-plugins-core"]
+      "args": [
+        "--from",
+        "qwen-mm-plugins[core] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-core-v1.0.2",
+        "qwen-mm-plugins-core"
+      ]
     }
   }
 }

--- a/src/capabilities/core/.codex-plugin/plugin.json
+++ b/src/capabilities/core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-mm-plugins-core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Qwen-MM-Plugins — read/visualize any file (images, video, PDF, Office, code, SVG, 3D, GIS, notebooks) plus OCR, grounding, segmentation, ASR and vision-chat, exposed as an MCP server.",
   "skills": "./skill",
   "mcpServers": "./.mcp.json"

--- a/src/capabilities/core/.mcp.json
+++ b/src/capabilities/core/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "qwen-mm-plugins[core] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-core-v1.0.1",
+        "qwen-mm-plugins[core] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-core-v1.0.2",
         "qwen-mm-plugins-core"
       ]
     }

--- a/src/capabilities/core/.qoder-plugin/plugin.json
+++ b/src/capabilities/core/.qoder-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qwen-mm-plugins-core",
   "displayName": "Qwen MM Plugins Core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Vision: read/visualize any file (images, video, PDF, Office, code, SVG, 3D, GIS, notebooks) plus OCR, grounding, segmentation, ASR and vision-chat as MCP tools.",
   "skills": "./skill",
   "mcp": ".mcp.json"

--- a/src/capabilities/core/qwen_mm_plugins_core/__init__.py
+++ b/src/capabilities/core/qwen_mm_plugins_core/__init__.py
@@ -8,7 +8,7 @@ from mcp_framework import build_registry
 
 from .stdio_streaming import streaming_stdio_server
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 # Auto-discover tools from these subpackages. Cloud API tools live in the qwen-mm-plugins-api
 # (vision_chat/ocr/grounding/segmentation/transcribe_audio) and qwen-mm-plugins-search

--- a/src/capabilities/search/.claude-plugin/plugin.json
+++ b/src/capabilities/search/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-mm-plugins-search",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Qwen-MM-Plugins search — web search and page extraction via Serper, Exa, or Tavily, plus Serper Lens reverse-image search, exposed as an MCP server.",
   "skills": [
     "./skill"
@@ -10,7 +10,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "qwen-mm-plugins[search] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-search-v1.0.2",
+        "qwen-mm-plugins[search] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-search-v1.0.3",
         "qwen-mm-plugins-search"
       ]
     }

--- a/src/capabilities/search/.codex-plugin/plugin.json
+++ b/src/capabilities/search/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-mm-plugins-search",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Qwen-MM-Plugins search — web search and page extraction via Serper, Exa, or Tavily, plus Serper Lens reverse-image search, exposed as an MCP server.",
   "skills": "./skill",
   "mcpServers": "./.mcp.json"

--- a/src/capabilities/search/.mcp.json
+++ b/src/capabilities/search/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "qwen-mm-plugins[search] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-search-v1.0.2",
+        "qwen-mm-plugins[search] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-search-v1.0.3",
         "qwen-mm-plugins-search"
       ]
     }

--- a/src/capabilities/search/.qoder-plugin/plugin.json
+++ b/src/capabilities/search/.qoder-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qwen-mm-plugins-search",
   "displayName": "Qwen MM Plugins Search",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Web search and page extraction via Serper, Exa, or Tavily, plus Serper Lens reverse-image search as MCP tools.",
   "skills": "./skill",
   "mcp": ".mcp.json"

--- a/src/capabilities/search/qwen_mm_plugins_search/__init__.py
+++ b/src/capabilities/search/qwen_mm_plugins_search/__init__.py
@@ -7,7 +7,7 @@ and Tavily through the package-local backend adapters. ``image_search`` uses Ser
 
 from mcp_framework import build_registry
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 # Auto-discover tools from tools/.
 SPECS, get_handler, list_tools = build_registry(__name__, ["tools"])

--- a/src/mcp_framework.py
+++ b/src/mcp_framework.py
@@ -14,7 +14,7 @@ Depends only on the `mcp` SDK (bundles FastMCP + pydantic) + anyio, so servers s
 
 from __future__ import annotations
 
-__version__ = "1.0.3"  # distribution/release-train version; plugin versions are per capability
+__version__ = "1.0.4"  # distribution/release-train version; plugin versions are per capability
 
 import asyncio
 import importlib

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -384,14 +384,14 @@ def test_local_install_uses_each_harness_native_command(tmp_path, harness, expec
                 "git ls-remote --exit-code",
                 "qwen extensions uninstall qwen-mm-plugins-core",
                 "qwen extensions install",
-                "--ref=qwen-mm-plugins-core-v1.0.1",
+                "--ref=qwen-mm-plugins-core-v1.0.2",
             ),
         ),
         (
             "gemini",
             (
                 "gemini mcp add -s user qwen-mm-plugins-core uvx --from",
-                "fetch --depth 1 origin qwen-mm-plugins-core-v1.0.1",
+                "fetch --depth 1 origin qwen-mm-plugins-core-v1.0.2",
                 "gemini skills install",
             ),
         ),
@@ -426,7 +426,7 @@ def test_qwen_update_restores_previous_ref_when_new_install_fails(tmp_path):
 confirm() { return 0; }
 run_cmd() {
   printf '$ %s\n' "$*"
-  case "$*" in *--ref=qwen-mm-plugins-core-v1.0.1*) return 1 ;; *) return 0 ;; esac
+  case "$*" in *--ref=qwen-mm-plugins-core-v1.0.2*) return 1 ;; *) return 0 ;; esac
 }
 update_for qwen-code qwen-mm-plugins-core
 test "$?" -eq 1
@@ -440,7 +440,7 @@ test "$?" -eq 1
 def test_cap_spec_defaults_to_capability_stable_tag():
     result = _bash("REPO_REF=; cap_spec search")
     assert result.returncode == 0, result.stderr
-    assert result.stdout.endswith("@qwen-mm-plugins-search-v1.0.2")
+    assert result.stdout.endswith("@qwen-mm-plugins-search-v1.0.3")
 
 
 def test_explicit_ref_overrides_package_and_marketplace():
@@ -456,7 +456,7 @@ def test_explicit_ref_overrides_package_and_marketplace():
 def test_gemini_skill_checkout_uses_same_stable_tag():
     result = _bash("QMP_DRY=1; REPO_REF=; install_gemini_skill gemini search")
     assert result.returncode == 0, result.stderr
-    assert "fetch --depth 1 origin qwen-mm-plugins-search-v1.0.2" in result.stdout
+    assert "fetch --depth 1 origin qwen-mm-plugins-search-v1.0.3" in result.stdout
     assert "--path src/capabilities/search/skill" in result.stdout
 
 
@@ -480,7 +480,7 @@ def test_post_update_hint_explains_how_to_activate_updated_components(harness, e
 def test_manual_update_prints_same_tag_for_skill_and_mcp_without_claiming_detection():
     result = _bash("show_manual update qwen-mm-plugins-search")
     assert result.returncode == 0, result.stderr
-    tag = "qwen-mm-plugins-search-v1.0.2"
+    tag = "qwen-mm-plugins-search-v1.0.3"
     repo = "https://github.com/QwenLM/Qwen-MM-Plugins.git"
     assert f"/tree/{tag}/src/capabilities/search/skill" in result.stdout
     assert f"qwen-mm-plugins[search] @ git+{repo}@{tag}" in result.stdout


### PR DESCRIPTION
## Summary

- document manual DeepSeek Harness setup, validated with `@deepseek-ai/dsh` 0.1.0-rc.6
- explain why DSH is not included in the installer’s harness picker
- add SOCKS proxy dependencies to the default `api` and `search` extras, removing the need for extra `--with` arguments
- document DSH’s current limitation for MCP image, audio, and resource blocks
- bump and synchronize the affected release metadata:
  - distribution: `1.0.4`
  - core: `1.0.2`
  - api: `1.0.3`
  - search: `1.0.3`

## Validation

- `359 passed, 3 skipped, 6 deselected`
- `python3 scripts/check_manifests.py`
- `bash -n install.sh`
- Ruff format and lint checks for modified Python files
- `git diff --check`

## Compatibility note

DSH rc.6 supports MCP text and structured results, but currently replaces image, audio, and resource content blocks with `content discarded`. Text-based results such as OCR, ASR, search, and `vision_chat` responses remain usable.