### PR TITLE
Document manual Hermes Agent setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The guided installer supports Claude Code, Codex, Qoder, OpenClaw, Qwen Code, an
 uses each harness's native install command and keeps shared configuration in
 `~/.qwen-mm-plugins/config`.
 
+Manual setup is also documented for DeepSeek Harness, Hermes Agent, opencode, pi, and QwenPaw in
+the [manual harness guide](docs/en/manual_harnesses.md).
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,6 +13,9 @@
 引导式安装器支持 Claude Code、Codex、Qoder、OpenClaw、Qwen Code 和 Gemini CLI。它调用各
 harness 的原生安装命令，并通过 `~/.qwen-mm-plugins/config` 共享配置。
 
+DeepSeek Harness、Hermes Agent、opencode、pi 和 QwenPaw 可参考
+[手动配置其他 Harness](docs/zh/manual_harnesses.md)。
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/QwenLM/Qwen-MM-Plugins/main/install.sh | bash
 ```

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -84,8 +84,8 @@ See [Local development](local_development.md) for direct source execution and ta
 
 ## Manual Skill + MCP installation
 
-Use this path for DeepSeek Harness, opencode, pi, QwenPaw, or another harness without a compatible
-marketplace. For an MCP capability, keep these three values aligned:
+Use this path for DeepSeek Harness, Hermes Agent, opencode, pi, QwenPaw, or another harness without
+a compatible marketplace. For an MCP capability, keep these three values aligned:
 
 - Skill: `src/capabilities/<cap>/skill`
 - package extra: `qwen-mm-plugins[<cap>]`

--- a/docs/en/manual_harnesses.md
+++ b/docs/en/manual_harnesses.md
@@ -109,6 +109,46 @@ search remain usable; workflows that depend on media returned by MCP are incompl
 upstream
 [`dsh-mcp-client` limitation](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/mcp/mcp-client/README.md#known-limitations-and-deferred-work).
 
+## Hermes Agent
+
+Validated with Hermes Agent v0.19.0. The Hermes installation must include MCP support
+(`hermes-agent[mcp]` or `hermes-agent[all]`). Copy the complete Skill directory from the same
+immutable tag used by the MCP command. Do not use the URL-based Skill installer here: Hermes v0.19
+may omit runtime files from referenced directories.
+
+```bash
+hermes_home=${HERMES_HOME:-"$HOME/.hermes"}
+mkdir -p "$hermes_home/skills"
+skill_target="$hermes_home/skills/qwen-mm-plugins-<cap>"
+[ ! -e "$skill_target" ] || \
+  mv "$skill_target" "$hermes_home/qwen-mm-plugins-<cap>.bak.$(date +%Y%m%d%H%M%S)"
+cp -R /path/to/tagged-checkout/src/capabilities/<cap>/skill \
+  "$skill_target"
+```
+
+Register and verify the MCP server (`edu-agent` is Skill-only):
+
+```bash
+uvx_bin=$(command -v uvx)
+hermes mcp add qwen-mm-plugins-<cap> \
+  --command "$uvx_bin" \
+  --connect-timeout 180 \
+  --args --from \
+  "qwen-mm-plugins[<cap>] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-<cap>-v<version>" \
+  qwen-mm-plugins-<cap>
+hermes mcp test qwen-mm-plugins-<cap>
+```
+
+Confirm that the test reports `Connected` and a nonzero tool count; Hermes v0.19 may exit with
+status 0 even after reporting a connection failure.
+
+**Compatibility:** At the provider boundary, Hermes is similar to DSH, but the mechanism differs.
+DSH discards MCP media blocks; Hermes caches returned images locally and sends only
+`MEDIA:<local-path>` text to the provider. Text and structured results remain usable, but the
+provider receives no image pixels. For `read_video`, timestamps and frame order remain while the
+original multi-frame visual context is lost; rereading individual cached frames does not restore
+that interleaved sequence.
+
 ## pi
 
 pi supports Skills directly; MCP tools require the community adapter:

--- a/docs/zh/installation.md
+++ b/docs/zh/installation.md
@@ -80,8 +80,8 @@ bash install.sh local --restore
 
 ## 手动安装 Skill + MCP
 
-DeepSeek Harness、opencode、pi、QwenPaw 或其他没有兼容 marketplace 的 harness 使用此方式。
-对于包含 MCP 的能力，以下三处名称必须一致：
+DeepSeek Harness、Hermes Agent、opencode、pi、QwenPaw 或其他没有兼容 marketplace 的
+harness 使用此方式。对于包含 MCP 的能力，以下三处名称必须一致：
 
 - Skill：`src/capabilities/<cap>/skill`
 - 包 extra：`qwen-mm-plugins[<cap>]`

--- a/docs/zh/manual_harnesses.md
+++ b/docs/zh/manual_harnesses.md
@@ -106,6 +106,43 @@ block 替换为 `content discarded`。`vision_chat`、OCR、ASR 和搜索等文�
 返回媒体内容的流程尚不完整。参见上游
 [`dsh-mcp-client` 限制](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/packages/mcp/mcp-client/README.md#known-limitations-and-deferred-work)。
 
+## Hermes Agent
+
+已使用 Hermes Agent v0.19.0 验证。Hermes 必须安装 MCP 支持（`hermes-agent[mcp]` 或
+`hermes-agent[all]`）。请从 MCP 命令所用的同一不可变 tag 复制完整 Skill 目录。这里不要使用
+基于 URL 的 Skill installer：Hermes v0.19 可能漏掉引用目录中的运行时文件。
+
+```bash
+hermes_home=${HERMES_HOME:-"$HOME/.hermes"}
+mkdir -p "$hermes_home/skills"
+skill_target="$hermes_home/skills/qwen-mm-plugins-<cap>"
+[ ! -e "$skill_target" ] || \
+  mv "$skill_target" "$hermes_home/qwen-mm-plugins-<cap>.bak.$(date +%Y%m%d%H%M%S)"
+cp -R /path/to/tagged-checkout/src/capabilities/<cap>/skill \
+  "$skill_target"
+```
+
+注册并验证 MCP server（`edu-agent` 是纯 Skill）：
+
+```bash
+uvx_bin=$(command -v uvx)
+hermes mcp add qwen-mm-plugins-<cap> \
+  --command "$uvx_bin" \
+  --connect-timeout 180 \
+  --args --from \
+  "qwen-mm-plugins[<cap>] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-<cap>-v<version>" \
+  qwen-mm-plugins-<cap>
+hermes mcp test qwen-mm-plugins-<cap>
+```
+
+请确认测试输出中包含 `Connected` 且工具数大于 0；Hermes v0.19 报告连接失败后仍可能
+以状态码 0 退出。
+
+**兼容性：** 在 provider 输入边界上，Hermes 与 DSH 类似，但机制不同。DSH 会丢弃 MCP 媒体
+block；Hermes 会在本地缓存返回的图片，仅向 provider 发送 `MEDIA:<本地路径>` 文本。文本和
+结构化结果仍可正常使用，但 provider 收不到图片像素。对于 `read_video`，时间戳和帧顺序会保留，
+但原始多帧视觉上下文会丢失；逐帧重新读取缓存图片也无法恢复原来的交错序列。
+
 ## pi
 
 pi 原生支持 Skill；MCP 工具需要社区 adapter：


### PR DESCRIPTION
## Summary

Document manual Qwen-MM-Plugins setup for Hermes Agent v0.19.0.

Hermes is intentionally not added to the guided installer. Its MCP media handling has limitations similar to DSH at the provider boundary, so the documentation presents it as a manual integration rather than a fully supported installer target.

## Changes

- Add Hermes Agent to the manual harness list.
- Document the required `hermes-agent[mcp]` or `hermes-agent[all]` installation.
- Copy the complete Skill directory from the same immutable tag used by the MCP server.
- Back up an existing Skill directory before replacing it.
- Register and verify MCP servers with `hermes mcp add` and `hermes mcp test`.
- Document Hermes MCP image-result limitations.

## Compatibility

Hermes caches images returned by MCP tools locally and sends the provider only a `MEDIA:<local-path>` string. The provider does not receive the image pixels.

Text and structured tool results remain usable. Image-returning workflows are limited; for example, `read_video` preserves timestamps and frame order, but not the original interleaved multi-frame visual context.

This differs from DSH in implementation—DSH discards media blocks entirely—but has a similar provider-visible limitation.

## Validation

Validated with Hermes Agent v0.19.0:

- Complete copied Skills are detected as enabled local Skills.
- `hermes mcp add` connected to the immutable `core` tag and discovered 7 tools.
- `hermes mcp test` reported `Connected` and `Tools discovered: 7`.
- Documentation diff and manifest consistency checks passed.