### PR TITLE
test: remove Ubuntu stdio handshake race

### DIFF
--- a/tests/test_e2e_stdio.py
+++ b/tests/test_e2e_stdio.py
@@ -13,8 +13,11 @@ The *server* needs the `mcp` SDK to run, so this skips when it's absent.
 
 import json
 import os
+import queue
 import subprocess
 import sys
+import threading
+import time
 
 import pytest
 from conftest import CORE_SERVER_DIR
@@ -33,42 +36,107 @@ def _rpc(method: str, params: dict | None = None, id_: int | None = None) -> str
     return json.dumps(msg) + "\n"
 
 
+_STDOUT_EOF = object()
+
+
+def _collect_stdout(stream, messages: queue.Queue) -> None:
+    """Decode stdout without blocking the test's request/response handshake."""
+    try:
+        for raw_line in stream:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                messages.put(json.loads(line))
+            except json.JSONDecodeError as exc:
+                messages.put(exc)
+                return
+    finally:
+        messages.put(_STDOUT_EOF)
+
+
+def _send(proc: subprocess.Popen, *messages: str) -> None:
+    assert proc.stdin is not None
+    proc.stdin.write("".join(messages))
+    proc.stdin.flush()
+
+
+def _wait_for_response(proc: subprocess.Popen, messages: queue.Queue, response_id: int, timeout: float = 30) -> dict:
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AssertionError(f"timed out waiting for JSON-RPC response {response_id}; process={proc.poll()}")
+        try:
+            message = messages.get(timeout=remaining)
+        except queue.Empty:
+            raise AssertionError(
+                f"timed out waiting for JSON-RPC response {response_id}; process={proc.poll()}"
+            ) from None
+        if message is _STDOUT_EOF:
+            raise AssertionError(f"server stdout closed before JSON-RPC response {response_id}; process={proc.poll()}")
+        if isinstance(message, BaseException):
+            raise AssertionError(f"non-JSON output from stdio server: {message}") from message
+        if message.get("id") == response_id:
+            return message
+
+
 @pytest.fixture(scope="module")
 def rpc_responses() -> dict[int, dict]:
     """Run one full handshake + tools/list against a fresh server subprocess.
 
-    All requests are written up front and stdin closed; the stdio server processes them
-    in order and exits on EOF. Returns the responses keyed by request id.
+    Wait for the initialize response before sending the initialized notification and
+    tools/list request, just like a real MCP client. Closing stdin before the server had
+    drained every request made this test race against EOF handling on fast Linux runners.
     """
-    wire = (
-        _rpc(
-            "initialize",
-            {
-                "protocolVersion": "2025-06-18",
-                "capabilities": {},
-                "clientInfo": {"name": "e2e-stdio-test", "version": "0"},
-            },
-            id_=1,
-        )
-        + _rpc("notifications/initialized")
-        + _rpc("tools/list", {}, id_=2)
-    )
-    proc = subprocess.run(
+    proc = subprocess.Popen(
         [sys.executable, CORE_SERVER_DIR],
-        input=wire.encode(),
-        capture_output=True,
-        timeout=120,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
         env=dict(os.environ),
     )
+    assert proc.stdout is not None
+    messages: queue.Queue = queue.Queue()
+    reader = threading.Thread(target=_collect_stdout, args=(proc.stdout, messages), daemon=True)
+    reader.start()
+
     responses = {}
-    for line in proc.stdout.decode().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        msg = json.loads(line)  # every stdout line must be valid JSON-RPC (nothing else may leak)
-        if "id" in msg:
-            responses[msg["id"]] = msg
-    assert responses, f"no JSON-RPC responses on stdout; stderr tail: {proc.stderr.decode()[-500:]}"
+    try:
+        _send(
+            proc,
+            _rpc(
+                "initialize",
+                {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "e2e-stdio-test", "version": "0"},
+                },
+                id_=1,
+            ),
+        )
+        responses[1] = _wait_for_response(proc, messages, 1)
+
+        _send(proc, _rpc("notifications/initialized"), _rpc("tools/list", {}, id_=2))
+        responses[2] = _wait_for_response(proc, messages, 2)
+    finally:
+        if proc.stdin is not None and not proc.stdin.closed:
+            try:
+                proc.stdin.close()
+            except BrokenPipeError:
+                pass
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)
+        reader.join(timeout=1)
+
+    assert proc.stderr is not None
+    stderr = proc.stderr.read()
+    assert proc.returncode == 0, f"stdio server exited with {proc.returncode}; stderr tail: {stderr[-500:]}"
     return responses
 
 


### PR DESCRIPTION
## Summary

- send the raw MCP `initialize` request and wait for its response before continuing
- send `notifications/initialized` and `tools/list` only after initialization completes
- keep stdin open until the `tools/list` response arrives
- read stdout asynchronously with a bounded, cross-platform timeout
- preserve the test's direct newline-delimited JSON-RPC coverage

## Why

The previous test wrote the complete handshake up front and immediately closed stdin. On fast Ubuntu runners, the MCP server could observe EOF and stop after returning only the initialize response, causing the intermittent failure:

```text
tests/test_e2e_stdio.py::test_tools_list_complete_schemas
AssertionError: tools/list failed: None
```

The same failure occurred on multiple unrelated `main` commits while macOS passed, confirming a test lifecycle race rather than a renderer or product regression.

## Validation

- 50/50 independent stdio handshake runs passed
- full offline suite: `395 passed, 2 skipped, 6 deselected`
- Ruff format and lint checks pass for the modified test

This is a test-only change and does not require a version bump or release tag.
