### PR TITLE
tests: skip STEP render case when cascadio is missing

### DIFF
--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -239,6 +239,7 @@ def _has_dep(key: str) -> bool:
         "nbformat": lambda: __import__("nbformat"),
         "geopandas": lambda: __import__("geopandas"),
         "trimesh": lambda: __import__("trimesh"),
+        "cascadio": lambda: __import__("cascadio"),  # trimesh STEP/STP loader
         "playwright": lambda: __import__("playwright"),
         "libreoffice": lambda: shutil.which("libreoffice") or shutil.which("soffice"),
         "pdflatex": lambda: shutil.which("pdflatex"),
@@ -339,7 +340,7 @@ TESTS = [
     ("sample.drawio", "image", 1, "DrawIO (XML → SVG)", ["resvg_py", "lxml"]),
     ("sample.srt", "text", 1, "SRT subtitle (text)", []),
     ("sample-model.glb", "image", 3, "GLB (blender)", ["blender"]),
-    ("GothicRoseWindow.step", "image", 3, "STEP (trimesh)", ["trimesh"]),
+    ("GothicRoseWindow.step", "image", 3, "STEP (trimesh)", ["trimesh", "cascadio"]),
     ("sample.geojson", "image", 1, "GeoJSON (geopandas)", ["geopandas"]),
     ("sample.ipynb", "text", 3, "Jupyter notebook", ["nbformat"]),
     ("charts.ipynb", "image", 3, "Jupyter notebook (charts)", ["nbformat"]),


### PR DESCRIPTION
## Problem

The parametrized renderer matrix in `tests/test_renderers.py` lists

```python
("GothicRoseWindow.step", "image", 3, "STEP (trimesh)", ["trimesh"]),
```

but rendering a `.step` file through `trimesh.load()` requires the `cascadio` package (declared in the `viz` extra). On a partial install where trimesh is present but cascadio is not, the skip guard passes and the test fails with a raw error instead of skipping:

```
AssertionError: Error rendering .step file: ModuleNotFoundError: No module named 'cascadio'
```

## Fix

- Add a `cascadio` availability probe to the `_has_dep()` helper.
- Add `cascadio` to the STEP case's `requires` list, so the test skips cleanly when the STEP loader is unavailable (matching how every other optional dependency in the matrix is handled).

With cascadio installed the case still runs exactly as before.