### PR TITLE
release: prepare core 1.0.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Qwen multimodal understanding plugins — Agent Skills + MCP servers",
-    "version": "1.0.7"
+    "version": "1.0.8"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "source": "git-subdir",
         "url": "https://github.com/QwenLM/Qwen-MM-Plugins.git",
         "path": "src/capabilities/core",
-        "ref": "qwen-mm-plugins-core-v1.0.4"
+        "ref": "qwen-mm-plugins-core-v1.0.5"
       },
       "description": "Read and visualize any file (images, video, docs, 3D, and more), plus image tools — crop, annotate, extract frames — as MCP tools."
     },

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ LOCAL_REPO_ROOT=''
 CAP_ITEMS=(core api search video-memory video-edit blender freecad edu-agent)
 # Latest stable plugin versions, in exactly the same order as CAP_ITEMS. Keep this release index in
 # sync with plugin-versions.json; scripts/check_manifests.py and tests/test_install_sh.py enforce it.
-CAP_VERSIONS=(1.0.4 1.0.5 1.0.4 1.0.3 1.0.2 1.0.2 1.0.2 1.0.2)
+CAP_VERSIONS=(1.0.5 1.0.5 1.0.4 1.0.3 1.0.2 1.0.2 1.0.2 1.0.2)
 CAP_DESC=("read/visualize any local file — images, video, docs, 3D"
           "cloud media APIs by model family: VL (vision_chat/ocr/grounding), Omni A/V, ASR, segmentation"
           "web search/extraction (Serper, Exa, Tavily) + Serper reverse-image search"

--- a/plugin-versions.json
+++ b/plugin-versions.json
@@ -1,10 +1,10 @@
 {
-  "distribution_version": "1.0.7",
+  "distribution_version": "1.0.8",
   "tag_format": "qwen-mm-plugins-{cap}-v{version}",
   "plugins": {
     "api": "1.0.5",
     "blender": "1.0.2",
-    "core": "1.0.4",
+    "core": "1.0.5",
     "edu-agent": "1.0.2",
     "freecad": "1.0.2",
     "search": "1.0.4",

--- a/src/capabilities/core/.claude-plugin/plugin.json
+++ b/src/capabilities/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-mm-plugins-core",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Qwen-MM-Plugins — read/visualize any file (images, video, PDF, Office, code, SVG, 3D, GIS, notebooks) plus OCR, grounding, segmentation, ASR and vision-chat, exposed as an MCP server.",
   "skills": [
     "./skill"
@@ -10,7 +10,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "qwen-mm-plugins[core] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-core-v1.0.4",
+        "qwen-mm-plugins[core] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-core-v1.0.5",
         "qwen-mm-plugins-core"
       ]
     }

--- a/src/capabilities/core/.codex-plugin/plugin.json
+++ b/src/capabilities/core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-mm-plugins-core",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Qwen-MM-Plugins — read/visualize any file (images, video, PDF, Office, code, SVG, 3D, GIS, notebooks) plus OCR, grounding, segmentation, ASR and vision-chat, exposed as an MCP server.",
   "skills": "./skill",
   "mcpServers": "./.mcp.json"

--- a/src/capabilities/core/.mcp.json
+++ b/src/capabilities/core/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "qwen-mm-plugins[core] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-core-v1.0.4",
+        "qwen-mm-plugins[core] @ git+https://github.com/QwenLM/Qwen-MM-Plugins.git@qwen-mm-plugins-core-v1.0.5",
         "qwen-mm-plugins-core"
       ]
     }

--- a/src/capabilities/core/.qoder-plugin/plugin.json
+++ b/src/capabilities/core/.qoder-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "qwen-mm-plugins-core",
   "displayName": "Qwen MM Plugins Core",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Vision: read/visualize any file (images, video, PDF, Office, code, SVG, 3D, GIS, notebooks) plus OCR, grounding, segmentation, ASR and vision-chat as MCP tools.",
   "skills": "./skill",
   "mcp": ".mcp.json"

--- a/src/capabilities/core/qwen_mm_plugins_core/__init__.py
+++ b/src/capabilities/core/qwen_mm_plugins_core/__init__.py
@@ -8,7 +8,7 @@ from mcp_framework import build_registry
 
 from .stdio_streaming import streaming_stdio_server
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 # Auto-discover tools from these subpackages. Cloud API tools live in the qwen-mm-plugins-api
 # (vision_chat/ocr/grounding/segmentation/transcribe_audio) and qwen-mm-plugins-search

--- a/src/mcp_framework.py
+++ b/src/mcp_framework.py
@@ -14,7 +14,7 @@ Depends only on the `mcp` SDK (bundles FastMCP + pydantic) + anyio, so servers s
 
 from __future__ import annotations
 
-__version__ = "1.0.7"  # distribution/release-train version; plugin versions are per capability
+__version__ = "1.0.8"  # distribution/release-train version; plugin versions are per capability
 
 import asyncio
 import importlib

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -448,14 +448,14 @@ def test_codebuddy_install_checks_inventory_when_cli_falsely_returns_zero(tmp_pa
                 "git ls-remote --exit-code",
                 "qwen extensions uninstall qwen-mm-plugins-core",
                 "qwen extensions install",
-                "--ref=qwen-mm-plugins-core-v1.0.4",
+                "--ref=qwen-mm-plugins-core-v1.0.5",
             ),
         ),
         (
             "gemini",
             (
                 "gemini mcp add -s user qwen-mm-plugins-core uvx --from",
-                "fetch --depth 1 origin qwen-mm-plugins-core-v1.0.4",
+                "fetch --depth 1 origin qwen-mm-plugins-core-v1.0.5",
                 "gemini skills install",
             ),
         ),
@@ -490,7 +490,7 @@ def test_qwen_update_restores_previous_ref_when_new_install_fails(tmp_path):
 confirm() { return 0; }
 run_cmd() {
   printf '$ %s\n' "$*"
-  case "$*" in *--ref=qwen-mm-plugins-core-v1.0.4*) return 1 ;; *) return 0 ;; esac
+  case "$*" in *--ref=qwen-mm-plugins-core-v1.0.5*) return 1 ;; *) return 0 ;; esac
 }
 update_for qwen-code qwen-mm-plugins-core
 test "$?" -eq 1


### PR DESCRIPTION
## Summary

- bump qwen-mm-plugins-core from 1.0.4 to 1.0.5
- bump the distribution release train from 1.0.7 to 1.0.8
- update marketplace, harness, MCP, and plugin refs to `qwen-mm-plugins-core-v1.0.5`
- align installer tests with the new stable core tag

## Validation

- `python3 scripts/check_manifests.py`
- `pytest tests/test_install_sh.py tests/test_tag_plugin_release.py tests/test_launch_autoinstall.py` (69 passed)
- Ruff format/check on changed Python files
- full offline suite: 427 passed, 2 skipped, with only the three old-tag assertions failing before their expected values were updated; all three pass in the targeted rerun