### PR TITLE
fix(shared): normalize box corner order before drawing

### DIFF
--- a/src/shared/image.py
+++ b/src/shared/image.py
@@ -91,6 +91,11 @@ def draw_boxes(img, detections: list[dict[str, Any]]):
     for i, det in enumerate(detections):
         color = det.get("color") or COLORS[i % len(COLORS)]
         x1, y1, x2, y2 = det["bbox_pixel"]
+        # A model may name the corners in either order; Pillow >= 9.5 raises on a
+        # rectangle whose second corner precedes the first, and in grounding that
+        # exception escapes the tool and discards the detections that were fine.
+        x1, x2 = sorted((x1, x2))
+        y1, y2 = sorted((y1, y2))
         draw.rectangle([x1, y1, x2, y2], outline=color, width=line_width)
 
         label = det.get("label") or ""

--- a/src/shared/image.py
+++ b/src/shared/image.py
@@ -91,9 +91,7 @@ def draw_boxes(img, detections: list[dict[str, Any]]):
     for i, det in enumerate(detections):
         color = det.get("color") or COLORS[i % len(COLORS)]
         x1, y1, x2, y2 = det["bbox_pixel"]
-        # A model may name the corners in either order; Pillow >= 9.5 raises on a
-        # rectangle whose second corner precedes the first, and in grounding that
-        # exception escapes the tool and discards the detections that were fine.
+        # Accept either corner order; Pillow requires top-left then bottom-right.
         x1, x2 = sorted((x1, x2))
         y1, y2 = sorted((y1, y2))
         draw.rectangle([x1, y1, x2, y2], outline=color, width=line_width)

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -634,8 +634,6 @@ def test_segmentation_returns_error_on_non_connection_failure(monkeypatch, sampl
 
 def test_grounding_draws_boxes_with_reversed_corners(monkeypatch, sample_image):
     pytest.importorskip("openai")
-    # The model names the corners in the other order. Pillow >= 9 raises on such a rectangle,
-    # and the draw sits outside grounding's try/except, so the whole tool call used to escape.
     model_json = '[{"label": "cat", "bbox_2d": [800, 100, 200, 400]}]'
     monkeypatch.setattr(oa, "call_openai_chat", lambda **kwargs: _chat_response(model_json))
 
@@ -644,5 +642,4 @@ def test_grounding_draws_boxes_with_reversed_corners(monkeypatch, sample_image):
     assert not _is_error(blocks)
     result = json.loads(blocks[0]["text"])
     assert result["detections"][0]["label"] == "cat"
-    # return_img=True with a detection → the annotated image block is appended, not an exception
     assert any(block["type"] == "image" for block in blocks)

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -630,3 +630,19 @@ def test_segmentation_returns_error_on_non_connection_failure(monkeypatch, sampl
     monkeypatch.setattr(requests, "post", _boom)
     out = segmentation.handle({"image_path": sample_image, "server": "http://sam3.invalid"})
     assert _is_error(out)
+
+
+def test_grounding_draws_boxes_with_reversed_corners(monkeypatch, sample_image):
+    pytest.importorskip("openai")
+    # The model names the corners in the other order. Pillow >= 9 raises on such a rectangle,
+    # and the draw sits outside grounding's try/except, so the whole tool call used to escape.
+    model_json = '[{"label": "cat", "bbox_2d": [800, 100, 200, 400]}]'
+    monkeypatch.setattr(oa, "call_openai_chat", lambda **kwargs: _chat_response(model_json))
+
+    blocks = grounding.handle({"image_path": sample_image, "prompt": "cat", "return_img": True})
+
+    assert not _is_error(blocks)
+    result = json.loads(blocks[0]["text"])
+    assert result["detections"][0]["label"] == "cat"
+    # return_img=True with a detection → the annotated image block is appended, not an exception
+    assert any(block["type"] == "image" for block in blocks)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -255,6 +255,30 @@ def test_visualize_missing_file():
     assert _is_error(visualize.handle({"file_path": "/no/such/file.pdf"}))
 
 
+# ── draw_bbox ────────────────────────────────────────────────────────
+
+
+def test_draw_bbox_accepts_reversed_corners(sample_image, tmp_path):
+    # The caller may name the corners in the other order; the box it describes is still drawn.
+    from PIL import Image
+
+    from qwen_mm_plugins_core.producers import draw_bbox
+
+    out = tmp_path / "annotated.png"
+    content = draw_bbox.handle(
+        {
+            "image_path": sample_image,
+            "bboxes": [{"bbox": [800, 100, 200, 400], "color": "#00FF00"}],
+            "output_path": str(out),
+        }
+    )
+    assert not _is_error(content)
+    annotated = Image.open(out)
+    assert annotated.size == (96, 64)
+    # [200, 100, 800, 400] on 96x64 is pixel [19, 6, 77, 26]; the top edge runs through (60, 6).
+    assert annotated.getpixel((60, 6)) == (0, 255, 0), "box was not drawn where the corners describe"
+
+
 # ── server protocol (real MCP client over stdio) ─────────────────────
 # Drives the installed/checked-out server binary through the official MCP SDK
 # client: full initialize handshake, tools/list, tools/call. This is the

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -259,7 +259,6 @@ def test_visualize_missing_file():
 
 
 def test_draw_bbox_accepts_reversed_corners(sample_image, tmp_path):
-    # The caller may name the corners in the other order; the box it describes is still drawn.
     from PIL import Image
 
     from qwen_mm_plugins_core.producers import draw_bbox
@@ -273,10 +272,10 @@ def test_draw_bbox_accepts_reversed_corners(sample_image, tmp_path):
         }
     )
     assert not _is_error(content)
-    annotated = Image.open(out)
-    assert annotated.size == (96, 64)
-    # [200, 100, 800, 400] on 96x64 is pixel [19, 6, 77, 26]; the top edge runs through (60, 6).
-    assert annotated.getpixel((60, 6)) == (0, 255, 0), "box was not drawn where the corners describe"
+    with Image.open(out) as annotated:
+        assert annotated.size == (96, 64)
+        # Pixel (60, 6) lies on the normalized box's top edge.
+        assert annotated.getpixel((60, 6)) == (0, 255, 0), "box was not drawn where the corners describe"
 
 
 # ── server protocol (real MCP client over stdio) ─────────────────────


### PR DESCRIPTION
## What changed

`draw_boxes` (`src/shared/image.py`) passes each `bbox_pixel` straight to Pillow's `draw.rectangle`, which since Pillow 9.5 raises `ValueError: x1 must be greater than or equal to x0` when the second corner precedes the first. This repo pins `pillow<12` with no lower bound, so every current Pillow raises. Two callers are exposed:

- `grounding` — a model reply that names the corners in the other order, e.g. `[{"label": "cat", "bbox_2d": [800, 100, 200, 400]}]`, parses fine, but with `return_img=true` the draw runs after the parser's `try/except`, so the exception escapes the tool and the detections that had parsed are lost with the call.
- `draw_bbox` (core) — the same line, with the reversed box coming from the caller's arguments.

The fix sorts each pair of corners before drawing, so any corner order draws the rectangle it describes and the label lands at its top-left. Well-ordered boxes are unchanged. Grounding's JSON still returns `bbox_normalized`/`bbox_pixel` exactly as the model emitted them; I left that alone because `crop` already rejects a reversed box with a clear message, but can canonicalize them at parse time as well if you prefer.

## Regression tests

- `tests/test_api_tools.py::test_grounding_draws_boxes_with_reversed_corners` — stubbed model reply with reversed corners and `return_img=True`: the tool returns its detections and the annotated image block instead of raising.
- `tests/test_tools.py::test_draw_bbox_accepts_reversed_corners` — `draw_bbox` with `[800, 100, 200, 400]` on the 96×64 sample image saves a 96×64 file whose top-edge pixel `(60, 6)` carries the requested outline colour, i.e. the box was drawn where the sorted corners put it.

Both fail on `main` and pass with the fix:

```
# on main:
tests/test_api_tools.py::test_grounding_draws_boxes_with_reversed_corners FAILED
    ValueError: x1 must be greater than or equal to x0
tests/test_tools.py::test_draw_bbox_accepts_reversed_corners FAILED
    ValueError: x1 must be greater than or equal to x0
```

## Verification

macOS, Python 3.12.14, Pillow 11.3.0:

```
$ python -m pytest -q -m "not reachability" tests/
445 passed, 30 skipped, 7 deselected in 26.94s      # main: 443 passed, 30 skipped, 7 deselected

$ python scripts/check_manifests.py
OK — 10 capabilities consistent across marketplace.json, plugin manifests and pyproject.toml

$ ruff check src/shared/image.py tests/test_api_tools.py tests/test_tools.py
All checks passed!

$ ruff format --check src/shared/image.py tests/test_api_tools.py
2 files already formatted
```

`tests/test_tools.py` already fails `ruff format --check` on `main` (ruff 0.16.6); I added to it without reformatting it (24 insertions, 0 deletions), so its format diff is identical before and after.

Not run: the opt-in `reachability` tests (credentialed; also deselected in CI) and the Ubuntu leg of the CI matrix. The grounding test stubs `call_openai_chat`, so nothing touches the network.

#51 also touches `src/shared/image.py` (it adds a function after `draw_boxes`); I merged the two locally in both orders — no conflict, combined tests pass.

## Compatibility

- [x] Existing MCP tool names, inputs, and outputs are unchanged, or the change is explained above. — Names, inputs and outputs are unchanged for well-ordered boxes; a reversed box now draws instead of raising.
- [x] Tests and documentation were updated where behavior changed. — Tests above; no documentation described the exception.
- [x] No credentials, private media, generated artifacts, or machine-specific configuration are included.

---

This fix was developed with AI assistance; every result quoted above comes from running the listed commands locally.
