### PR TITLE
feat(api): add OpenRouter and standardize sampled video inputs

### DIFF
--- a/cookbooks/api/usage.md
+++ b/cookbooks/api/usage.md
@@ -22,6 +22,7 @@ Set credentials through the installer's **Configure** action, environment variab
 |---|---|
 | `DASHSCOPE_API_KEY` | DashScope vision, Omni, and Qwen3-ASR calls |
 | `ORCAROUTER_API_KEY` | Calls to `api.orcarouter.ai` |
+| `OPENROUTER_API_KEY` | Calls to `openrouter.ai` |
 | `DASHSCOPE_BASE_URL` | Default OpenAI-compatible endpoint for VL and Omni calls |
 | `ASR_SERVER_URLS` | Self-hosted Qwen3-ASR fallback |
 | `SAM3_SERVER_URL` | Self-hosted segmentation service |
@@ -52,8 +53,9 @@ limits. Omni tools use non-realtime HTTP models.
 
 Pass `base_url` and `model` to select another compatible service. An explicit `base_url` overrides
 `DASHSCOPE_BASE_URL`, and an explicit `api_key` overrides the configured key. DashScope endpoints
-read `DASHSCOPE_API_KEY`; `api.orcarouter.ai` reads `ORCAROUTER_API_KEY`. For other endpoints,
-pass `api_key` if authentication is required, or omit it for an authentication-free server.
+read `DASHSCOPE_API_KEY`; `api.orcarouter.ai` reads `ORCAROUTER_API_KEY`; `openrouter.ai` reads
+`OPENROUTER_API_KEY`. For other endpoints, pass `api_key` if authentication is required, or omit it
+for an authentication-free server.
 The endpoint and model must support the selected tool's media format.
 
 ### OrcaRouter example
@@ -77,6 +79,30 @@ Call `vision_chat` with these arguments, replacing the image path with your own 
 
 The call reads `ORCAROUTER_API_KEY` automatically. See the
 [OrcaRouter model catalog](https://www.orcarouter.ai/models) for other model IDs.
+
+### OpenRouter example
+
+Add your key through **Configure** or in `~/.qwen-mm-plugins/config`:
+
+```text
+OPENROUTER_API_KEY=your-openrouter-api-key
+```
+
+Call `vision_chat` with these arguments, replacing the image path with your own file:
+
+```json
+{
+  "base_url": "https://openrouter.ai/api/v1",
+  "model": "qwen/qwen3.7-plus",
+  "images": ["/absolute/path/photo.jpg"],
+  "text": "Describe the main objects in this image."
+}
+```
+
+The call reads `OPENROUTER_API_KEY` automatically. This example uses
+[Qwen3.7 Plus](https://openrouter.ai/qwen/qwen3.7-plus), which supports image input. See
+[OpenRouter authentication](https://openrouter.ai/docs/api_reference/authentication) for key setup
+and the [model catalog](https://openrouter.ai/models) for other model IDs and supported media.
 
 ## Tools
 

--- a/cookbooks/api/usage.md
+++ b/cookbooks/api/usage.md
@@ -104,6 +104,21 @@ The call reads `OPENROUTER_API_KEY` automatically. This example uses
 [OpenRouter authentication](https://openrouter.ai/docs/api_reference/authentication) for key setup
 and the [model catalog](https://openrouter.ai/models) for other model IDs and supported media.
 
+For video, pass `videos` and a suitable model, such as
+[Qwen3.8 Max](https://openrouter.ai/qwen/qwen3.8-max-0902):
+
+```json
+{
+  "base_url": "https://openrouter.ai/api/v1",
+  "model": "qwen/qwen3.8-max-0902",
+  "videos": ["/absolute/path/clip.mp4"],
+  "text": "Summarize the scene changes in chronological order."
+}
+```
+
+Local sampled frames are sent as ordered images. Direct video URLs and video data URLs require
+a model and provider that support [video input](https://openrouter.ai/docs/guides/overview/multimodal/videos).
+
 ## Tools
 
 ### Vision
@@ -140,10 +155,10 @@ See the [API Skill](../../src/capabilities/api/skill/SKILL.md) and MCP tool sche
 
 Remote URLs are passed to the endpoint for fetching. Local videos use these delivery paths:
 
-- **Vision**: sample local frames, or upload the video to OSS and send a signed URL when OSS is
-  configured and the video fits the model's duration limit. Inline requests support up to 250
-  media items, including images and frames.
-- **Omni**: transcode to fit the inline budget, then use OSS or sampled frames plus audio for
+- **Vision**: send local sampled frames as ordered images, or upload the video to OSS and send a
+  signed URL when OSS is configured and the video fits the model's duration limit. Inline requests
+  support up to 250 media items, including images and frames.
+- **Omni**: transcode to fit the inline budget, then use OSS or ordered images plus audio for
   larger videos.
 
 `dry_run=true` previews a VL or Omni request. For long recordings, use

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -17,8 +17,8 @@ Set `QWEN_MM_NATIVE_MODE=0` when the host model is text-only. Every returned ima
 at the same position by a generated caption, while existing text blocks (file metadata, PDF text
 layers, video timestamps, and similar context) are preserved. The caption path uses
 `DASHSCOPE_BASE_URL` and `QWEN_MM_API_VL_MODEL`. Credentials are selected by endpoint: DashScope uses
-`DASHSCOPE_API_KEY`, and OrcaRouter uses `ORCAROUTER_API_KEY`. Authentication-free local endpoints
-need no key configuration. A failed caption call produces an explicit
+`DASHSCOPE_API_KEY`, OrcaRouter uses `ORCAROUTER_API_KEY`, and OpenRouter uses `OPENROUTER_API_KEY`.
+Authentication-free local endpoints need no key configuration. A failed caption call produces an explicit
 `Visual content unavailable` text block instead of exposing base64 or silently dropping the image.
 
 Enabling text-only mode sends tool-result images—including local files and application or desktop
@@ -46,6 +46,7 @@ come from [`CONFIG_FIELDS`](../../src/shared/env.py); `—` means unset or disab
 |---|---|---|
 | `DASHSCOPE_API_KEY` | — | vision, OCR, grounding, text-only image captions, ASR, generation, memory builds *(secret)* |
 | `ORCAROUTER_API_KEY` | — | OpenAI-compatible calls to api.orcarouter.ai *(secret)* |
+| `OPENROUTER_API_KEY` | — | OpenAI-compatible calls to openrouter.ai *(secret)* |
 | `MINIMAX_API_KEY` | — | MiniMax text-to-speech generation *(secret)* |
 | `DASHSCOPE_BASE_URL` | DashScope compat URL | override the DashScope OpenAI-compatible base URL |
 | `QWEN_MM_API_VL_MODEL` | qwen3.7-plus | default VL model for vision_chat, OCR, grounding, and text-only image captions |

--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,7 @@ ALL_HARNESSES="$MP_HARNESSES $CFG_HARNESSES"
 CONFIG_SPEC=(
   "DASHSCOPE_API_KEY|1|services||vision, OCR, grounding, text-only image captions, ASR, generation, memory builds"
   "ORCAROUTER_API_KEY|1|services||OpenAI-compatible calls to api.orcarouter.ai"
+  "OPENROUTER_API_KEY|1|services||OpenAI-compatible calls to openrouter.ai"
   "MINIMAX_API_KEY|1|services||MiniMax text-to-speech generation"
   "DASHSCOPE_BASE_URL|0|services|DashScope compat URL|override the DashScope OpenAI-compatible base URL"
   "QWEN_MM_API_VL_MODEL|0|services|qwen3.7-plus|default VL model for vision_chat, OCR, grounding, and text-only image captions"

--- a/src/capabilities/api/qwen_mm_plugins_api/omni/_common.py
+++ b/src/capabilities/api/qwen_mm_plugins_api/omni/_common.py
@@ -395,7 +395,7 @@ def _frames_and_audio_parts(file_path: str, fps: float, max_pixels: int, cleanup
     """Decompose a too-long local video into a frame list + its audio track + a timestamp note.
 
     Omni's image-list video form carries no audio, so the sound track rides along as its own part and
-    the model combines them (multi-modal combination in one request needs a Qwen3.5-Omni model). The
+    the model combines them when it supports image and audio input in one request. The
     inline budget is split: speech only exists in the sound track, so that is fitted first — up to
     ``_AUDIO_SHARE``, stretched to ``_AUDIO_SHARE_MAX`` when the floor bitrate needs it — and the frames
     take whatever is left.
@@ -571,14 +571,6 @@ def run_omni(
     cleanup: list[str] = []
     try:
         parts = _build_media_parts(file_path, mode, fps, max_pixels, cleanup, omni_video_max_sec(model), model)
-        if any(p.get("type") == "video" and isinstance(p.get("video"), list) for p in parts) and (
-            "qwen3.5-omni" not in model
-        ):
-            log.warning(
-                "model %r may reject a frame list combined with audio — multi-modal combination in one "
-                "request is documented for the Qwen3.5-Omni series only",
-                model,
-            )
         messages = [{"role": "user", "content": [*parts, {"type": "text", "text": prompt}]}]
         if json_output:
             data = call_omni_json(

--- a/src/capabilities/api/qwen_mm_plugins_api/vl/vision_chat.py
+++ b/src/capabilities/api/qwen_mm_plugins_api/vl/vision_chat.py
@@ -64,6 +64,7 @@ def handle(arguments: dict[str, Any]) -> list[dict[str, Any]]:
         call_openai_chat,
         encode_image_source,
         encode_video_source,
+        expand_video_frames,
         resolve_openai_endpoint,
         resolve_vl_model,
     )
@@ -104,6 +105,7 @@ def handle(arguments: dict[str, Any]) -> list[dict[str, Any]]:
             # Preview the first wire request, where the shared client merges optional hints into
             # extra_body. Keep the internal optional_extra_body control out of the payload.
             preview_request = dict(kwargs)
+            preview_request["messages"] = expand_video_frames(messages)
             if optional_extra_body:
                 preview_request["extra_body"] = optional_extra_body
             payload: dict[str, Any] = {"base_url": base_url, "request": preview_request}
@@ -118,10 +120,6 @@ def handle(arguments: dict[str, Any]) -> list[dict[str, Any]]:
                 )
             for msg in payload["request"]["messages"]:
                 for item in msg.get("content", []):
-                    if item.get("type") == "video" and "video" in item:
-                        item["video"] = [
-                            f"<base64 frame {i + 1}/{len(item['video'])}>" for i in range(len(item["video"]))
-                        ]
                     if item.get("type") == "image_url":
                         url = item.get("image_url", {}).get("url", "")
                         if url.startswith("data:"):

--- a/src/capabilities/api/skill/SKILL.md
+++ b/src/capabilities/api/skill/SKILL.md
@@ -46,6 +46,8 @@ Check the `qwen-mm-plugins-api` tools in your tool list for full schemas and par
 **OrcaRouter**: configure `ORCAROUTER_API_KEY`, then pass `base_url="https://api.orcarouter.ai/v1"` and a gateway `model` ID. The server selects that key automatically; an explicit `api_key` overrides it.
 
 **OpenRouter**: configure `OPENROUTER_API_KEY`, then pass `base_url="https://openrouter.ai/api/v1"` and an OpenRouter `model` ID, such as `qwen/qwen3.7-plus` for images. The server selects that key automatically; an explicit `api_key` overrides it.
+For video, use `videos` with a suitable model such as `qwen/qwen3.8-max-0902`. Local sampled frames
+are sent as ordered images; direct video URLs require video support from the model and provider.
 
 **Grounding**: returns normalized boxes (0–1000). Set `return_img=true` to get the annotated image back, or draw them yourself with core's `draw_bbox`.
 

--- a/src/capabilities/api/skill/SKILL.md
+++ b/src/capabilities/api/skill/SKILL.md
@@ -45,6 +45,8 @@ Check the `qwen-mm-plugins-api` tools in your tool list for full schemas and par
 
 **OrcaRouter**: configure `ORCAROUTER_API_KEY`, then pass `base_url="https://api.orcarouter.ai/v1"` and a gateway `model` ID. The server selects that key automatically; an explicit `api_key` overrides it.
 
+**OpenRouter**: configure `OPENROUTER_API_KEY`, then pass `base_url="https://openrouter.ai/api/v1"` and an OpenRouter `model` ID, such as `qwen/qwen3.7-plus` for images. The server selects that key automatically; an explicit `api_key` overrides it.
+
 **Grounding**: returns normalized boxes (0–1000). Set `return_img=true` to get the annotated image back, or draw them yourself with core's `draw_bbox`.
 
 **ASR** (`transcribe_audio`): accepts audio or video, auto-chunks long files. Formats: `srt` (default), `text`, `json`. Uses DashScope with `DASHSCOPE_API_KEY`; configured `ASR_SERVER_URLS` provide a self-hosted fallback when the key is absent or DashScope fails. Needs `ffmpeg` for audio extraction and chunking.

--- a/src/shared/api_omni.py
+++ b/src/shared/api_omni.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
-from shared.api_openai import is_url, resolve_openai_endpoint
+from shared.api_openai import expand_video_frames, is_url, resolve_openai_endpoint
 from shared.env import get_env
 
 log = logging.getLogger(__name__)
@@ -172,11 +172,11 @@ def omni_video_part(source: str, *, fps: float = DEFAULT_OMNI_FPS, max_pixels: i
 
 
 def omni_frames_part(frames: list[str]) -> dict:
-    """The image-list video form: ``{"type": "video", "video": [<image>, …]}``.
+    """Build an internal frame list; chat clients expand it to ordered ``image_url`` parts.
 
-    Each entry is an image URL or a base64 ``data:`` URL of one frame; Omni treats the list as a video
-    but — unlike the file form — it carries NO audio, so pair it with ``omni_audio_part`` whenever the
-    source had a sound track (combining modalities in one request needs a Qwen3.5-Omni model).
+    Each entry is an image URL or a base64 ``data:`` URL of one frame. The list carries no audio,
+    so pair it with ``omni_audio_part`` whenever the source had a sound track and the model supports
+    combined image and audio input.
     Frames must be in chronological order; tell the model their timestamps in the text part, since the
     list itself has no time base.
     """
@@ -295,6 +295,8 @@ def call_omni(
     body = {"modalities": ["text"]}
     if extra_body:
         body.update(extra_body)
+
+    messages = expand_video_frames(messages)
 
     retryable = (
         openai.RateLimitError,

--- a/src/shared/api_openai.py
+++ b/src/shared/api_openai.py
@@ -79,6 +79,7 @@ _API_KEY_ENV_BY_HOST: dict[str, str] = {
     "dashscope.aliyuncs.com": "DASHSCOPE_API_KEY",
     "dashscope-intl.aliyuncs.com": "DASHSCOPE_API_KEY",
     "api.orcarouter.ai": "ORCAROUTER_API_KEY",
+    "openrouter.ai": "OPENROUTER_API_KEY",
 }
 
 

--- a/src/shared/api_openai.py
+++ b/src/shared/api_openai.py
@@ -96,6 +96,29 @@ def resolve_openai_endpoint(arguments: dict[str, Any]) -> tuple[str, str]:
     return base_url, api_key
 
 
+def expand_video_frames(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Send sampled video frames as ordered, standard ``image_url`` content parts.
+
+    Preserve the frame rate, video URLs, and other media without mutating the caller's messages.
+    """
+    prepared = []
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            prepared.append(message)
+            continue
+        parts = []
+        for part in content:
+            if part.get("type") != "video" or not isinstance(part.get("video"), list):
+                parts.append(part)
+                continue
+            fps = f" at {part['fps']} fps" if part.get("fps") else ""
+            parts.append({"type": "text", "text": f"Video frames in chronological order{fps}:"})
+            parts.extend({"type": "image_url", "image_url": {"url": frame}} for frame in part["video"])
+        prepared.append({**message, "content": parts})
+    return prepared
+
+
 def is_url(value: str) -> bool:
     return value.startswith(("http://", "https://", "data:"))
 
@@ -202,6 +225,8 @@ def call_openai_chat(
         )
 
     base_extra_body = kwargs.get("extra_body") or {}
+    if "messages" in kwargs:
+        kwargs["messages"] = expand_video_frames(kwargs["messages"])
     client = OpenAI(api_key=api_key, base_url=base_url, timeout=_chat_timeout())
 
     def _create(hints: dict[str, Any] | None) -> Any:

--- a/src/shared/env.py
+++ b/src/shared/env.py
@@ -164,6 +164,13 @@ CONFIG_FIELDS: list[tuple[str, bool, str, str, str]] = [
         "OpenAI-compatible calls to api.orcarouter.ai",
     ),
     (
+        "OPENROUTER_API_KEY",
+        True,
+        "Media APIs & endpoints",
+        "",
+        "OpenAI-compatible calls to openrouter.ai",
+    ),
+    (
         "MINIMAX_API_KEY",
         True,
         "Media APIs & endpoints",

--- a/tests/test_api_clients.py
+++ b/tests/test_api_clients.py
@@ -127,25 +127,62 @@ def test_model_resolvers_use_explicit_env_then_builtin(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "base_url,orca_key,explicit_key,expected_key",
+    "base_url,missing_key,explicit_key,expected_key",
     [
-        (None, "orca", None, "dashscope"),
-        ("https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "orca", None, "dashscope"),
-        ("https://api.orcarouter.ai/v1", "orca", None, "orca"),
-        ("https://api.orcarouter.ai/v1", None, None, "EMPTY"),
-        ("https://api.orcarouter.ai/v1", "orca", "explicit", "explicit"),
-        ("https://api.orcarouter.ai.example/v1", "orca", None, "EMPTY"),
-        ("http://localhost:8000/v1", "orca", None, "EMPTY"),
-        ("http://localhost:8000/v1", "orca", "custom", "custom"),
+        (None, None, None, "dashscope"),
+        ("https://dashscope-intl.aliyuncs.com/compatible-mode/v1", None, None, "dashscope"),
+        ("https://api.orcarouter.ai/v1", None, None, "orca"),
+        ("https://api.orcarouter.ai/v1", "ORCAROUTER_API_KEY", None, "EMPTY"),
+        ("https://api.orcarouter.ai/v1", None, "explicit", "explicit"),
+        ("https://api.orcarouter.ai.example/v1", None, None, "EMPTY"),
+        ("https://openrouter.ai/api/v1", None, None, "openrouter"),
+        ("https://openrouter.ai/api/v1", "OPENROUTER_API_KEY", None, "EMPTY"),
+        ("https://openrouter.ai/api/v1", None, "explicit", "explicit"),
+        ("https://openrouter.ai.example/api/v1", None, None, "EMPTY"),
+        ("http://localhost:8000/v1", None, None, "EMPTY"),
+        ("http://localhost:8000/v1", None, "custom", "custom"),
     ],
 )
-def test_endpoint_selects_key_by_host(monkeypatch, base_url, orca_key, explicit_key, expected_key):
-    values = {"DASHSCOPE_API_KEY": "dashscope", "ORCAROUTER_API_KEY": orca_key}
+def test_endpoint_selects_key_by_host(monkeypatch, base_url, missing_key, explicit_key, expected_key):
+    values = {
+        "DASHSCOPE_API_KEY": "dashscope",
+        "ORCAROUTER_API_KEY": "orca",
+        "OPENROUTER_API_KEY": "openrouter",
+    }
+    if missing_key:
+        del values[missing_key]
     monkeypatch.setattr(oa, "get_env", values.get)
     arguments = {"base_url": base_url, "api_key": explicit_key}
     expected = (base_url or oa.DEFAULT_DASHSCOPE_BASE_URL, expected_key)
     assert oa.resolve_openai_endpoint(arguments) == expected
     assert omni.resolve_omni_endpoint(arguments) == expected
+
+
+def test_openrouter_endpoint_from_config(monkeypatch, tmp_path):
+    import shared.env as env
+
+    config = tmp_path / "config"
+    config.write_text(
+        "DASHSCOPE_BASE_URL=https://openrouter.ai/api/v1\n"
+        "OPENROUTER_API_KEY=config-openrouter\n"
+        "DASHSCOPE_API_KEY=config-dashscope\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("QWEN_MM_CONFIG", str(config))
+    for key in ("DASHSCOPE_BASE_URL", "OPENROUTER_API_KEY", "DASHSCOPE_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(env, "_config_cache", None)
+
+    for resolve in (oa.resolve_openai_endpoint, omni.resolve_omni_endpoint):
+        assert resolve({}) == ("https://openrouter.ai/api/v1", "config-openrouter")
+        assert resolve({"base_url": oa.DEFAULT_DASHSCOPE_BASE_URL}) == (
+            oa.DEFAULT_DASHSCOPE_BASE_URL,
+            "config-dashscope",
+        )
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "env-openrouter")
+    for resolve in (oa.resolve_openai_endpoint, omni.resolve_omni_endpoint):
+        assert resolve({}) == ("https://openrouter.ai/api/v1", "env-openrouter")
 
 
 class _FakeCompletions:

--- a/tests/test_api_clients.py
+++ b/tests/test_api_clients.py
@@ -8,7 +8,9 @@ module's attribute is enough, no live network.
 
 import base64
 import io
+from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -212,6 +214,52 @@ def _install_fake_openai(monkeypatch, behavior):
     monkeypatch.setattr(openai, "OpenAI", factory)
     monkeypatch.setattr(sr.time, "sleep", lambda *_: None)
     return holder
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://openrouter.ai/api/v1",
+        "http://localhost:8000/v1",
+        oa.DEFAULT_DASHSCOPE_BASE_URL,
+        "https://api.orcarouter.ai/v1",
+    ],
+)
+def test_clients_send_video_frames_as_ordered_images(monkeypatch, streaming, base_url):
+    frame_urls = [f"https://example.com/frame{i}.jpg" for i in range(4)]
+    other_parts = [
+        {"type": "input_audio", "input_audio": {"data": "YQ==", "format": "wav"}},
+        {"type": "video_url", "video_url": {"url": "https://example.com/clip.mp4"}},
+        {"type": "text", "text": "Describe the videos."},
+    ]
+    messages = [
+        {"role": "system", "content": "Describe media."},
+        {
+            "role": "user",
+            "content": [
+                {"type": "video", "video": frame_urls[:2], "fps": 2},
+                {"type": "video", "video": frame_urls[2:]},
+                *other_parts,
+            ],
+        },
+    ]
+    original = deepcopy(messages)
+    chunk = SimpleNamespace(usage=None, choices=[SimpleNamespace(delta=SimpleNamespace(content="ok"))])
+    holder = _install_fake_openai(monkeypatch, lambda _: [chunk] if streaming else "ok")
+    call = omni.call_omni if streaming else oa.call_openai_chat
+    call(base_url=base_url, api_key="test-key", model="test-model", messages=messages)
+    sent = holder["client"].chat.completions.seen[0]["messages"]
+
+    assert messages == original
+    assert sent[0] == original[0]
+    assert sent[1]["role"] == "user"
+    parts = sent[1]["content"]
+    assert not any(part["type"] == "video" for part in parts)
+    assert [part["image_url"]["url"] for part in parts if part["type"] == "image_url"] == frame_urls
+    assert parts[-3:] == other_parts
+    assert "2 fps" in parts[0]["text"]
+    assert parts[3]["type"] == "text"
 
 
 def test_call_openai_chat_retries_transient_then_succeeds(monkeypatch):

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -299,6 +299,28 @@ def test_vision_chat_model_precedence(monkeypatch):
     assert explicit_payload["request"]["model"] == "explicit-vl"
 
 
+@pytest.mark.parametrize("base_url", [oa.DEFAULT_DASHSCOPE_BASE_URL, "https://openrouter.ai/api/v1"])
+def test_vision_chat_preview_contains_sampled_images(monkeypatch, sample_video, base_url):
+    from shared import oss
+
+    monkeypatch.setattr(oss, "is_upload_configured", lambda: False)
+    blocks = vision_chat.handle(
+        {
+            "base_url": base_url,
+            "videos": [sample_video],
+            "video_max_frames": 4,
+            "dry_run": True,
+        }
+    )
+    payload = json.loads(blocks[0]["text"])
+    parts = payload["request"]["messages"][0]["content"]
+    assert not any(part["type"] == "video" for part in parts)
+    images = [part for part in parts if part["type"] == "image_url"]
+    assert len(images) == 4
+    assert all(part["image_url"]["url"].startswith("<base64 image") for part in images)
+    assert "fps" in parts[0]["text"]
+
+
 def test_encode_video_source_uploads_to_oss_when_configured(monkeypatch):
     """Unified OSS trigger: a local video is uploaded and passed by URL when OSS is configured —
     no local frame extraction (so this needs neither ffmpeg nor a real file)."""


### PR DESCRIPTION
## What changed

Calls to `https://openrouter.ai/api/v1` now select `OPENROUTER_API_KEY` from the environment or shared config automatically. An explicit `api_key` still takes precedence, and a missing OpenRouter key does not fall back to another provider's credentials.

Sampled video frames now use ordered `image_url` parts across all endpoints. OpenRouter silently ignored the previous `type: video` frame lists even when it returned HTTP 200. The shared VL and Omni clients now send standard image lists with frame-rate context, preserving other media parts and direct video URLs. VL previews show the same format.

Add the key to the installer's secret settings and configuration reference, with API Skill guidance and image/video cookbook examples.

## Verification

- Offline suite: `python -m pytest -q -m "not reachability" tests/` — 512 passed, 4 skipped, 7 deselected.
- Regression coverage includes credential isolation/precedence, frame order and frame-rate context, preservation of other media and original messages, streaming/non-streaming clients, and video previews.
- `python scripts/check_manifests.py`, `bash -n install.sh`, and `git diff --check` passed. Configuration catalog consistency is covered by the suite.
- Changed Python files pass Ruff lint and formatting checks. Repository-wide checks still report 19 existing lint errors and 45 files requiring formatting outside this change.
- Live stdio MCP: OpenRouter image input (`qwen/qwen3.7-plus`); local video on OpenRouter (`qwen/qwen3.8-max-0902`), DashScope (`qwen3.7-plus`), and OrcaRouter (`z-ai/glm-5.3-flash-free`). All video calls correctly read three distinct scene labels in chronological order. OpenRouter MP4 data URLs also passed.
- DashScope `qwen3.5-omni-plus` streaming frame input passed through the shared client. Validated both cookbook examples against the tool schema and credential resolver. Audio input and remote HTTP video URLs were not tested.

## Compatibility

- [x] Existing MCP tool names, inputs, and outputs are unchanged, or the change is explained above.
- [x] Tests and documentation were updated where behavior changed.
- [x] No credentials, private media, generated artifacts, or machine-specific configuration are included.
